### PR TITLE
Fix config context to be a map of objects

### DIFF
--- a/netbox/models/device_with_config_context.go
+++ b/netbox/models/device_with_config_context.go
@@ -49,7 +49,7 @@ type DeviceWithConfigContext struct {
 
 	// Config context
 	// Read Only: true
-	ConfigContext map[string]string `json:"config_context,omitempty"`
+	ConfigContext map[string]interface{} `json:"config_context,omitempty"`
 
 	// Created
 	// Read Only: true

--- a/netbox/models/virtual_machine_with_config_context.go
+++ b/netbox/models/virtual_machine_with_config_context.go
@@ -44,7 +44,7 @@ type VirtualMachineWithConfigContext struct {
 
 	// Config context
 	// Read Only: true
-	ConfigContext map[string]string `json:"config_context,omitempty"`
+	ConfigContext map[string]interface{} `json:"config_context,omitempty"`
 
 	// Created
 	// Read Only: true

--- a/netbox/models/writable_device_with_config_context.go
+++ b/netbox/models/writable_device_with_config_context.go
@@ -49,7 +49,7 @@ type WritableDeviceWithConfigContext struct {
 
 	// Config context
 	// Read Only: true
-	ConfigContext map[string]string `json:"config_context,omitempty"`
+	ConfigContext map[string]interface{} `json:"config_context,omitempty"`
 
 	// Created
 	// Read Only: true

--- a/netbox/models/writable_virtual_machine_with_config_context.go
+++ b/netbox/models/writable_virtual_machine_with_config_context.go
@@ -44,7 +44,7 @@ type WritableVirtualMachineWithConfigContext struct {
 
 	// Config context
 	// Read Only: true
-	ConfigContext map[string]string `json:"config_context,omitempty"`
+	ConfigContext map[string]interface{} `json:"config_context,omitempty"`
 
 	// Created
 	// Read Only: true

--- a/swagger.json
+++ b/swagger.json
@@ -36098,7 +36098,7 @@
           "title": "Config context",
           "type": "object",
           "additionalProperties": {
-            "type": "string"
+            "type": "object"
           },
           "readOnly": true
         },
@@ -36281,7 +36281,7 @@
           "title": "Config context",
           "type": "object",
           "additionalProperties": {
-            "type": "string"
+            "type": "object"
           },
           "readOnly": true
         },
@@ -46091,7 +46091,7 @@
           "title": "Config context",
           "type": "object",
           "additionalProperties": {
-            "type": "string"
+            "type": "object"
           },
           "readOnly": true
         },
@@ -46231,7 +46231,7 @@
           "title": "Config context",
           "type": "object",
           "additionalProperties": {
-            "type": "string"
+            "type": "object"
           },
           "readOnly": true
         },

--- a/swagger.processed.json
+++ b/swagger.processed.json
@@ -36098,7 +36098,7 @@
           "title": "Config context",
           "type": "object",
           "additionalProperties": {
-            "type": "string"
+            "type": "object"
           },
           "readOnly": true
         },
@@ -36281,7 +36281,7 @@
           "title": "Config context",
           "type": "object",
           "additionalProperties": {
-            "type": "string"
+            "type": "object"
           },
           "readOnly": true
         },
@@ -46091,7 +46091,7 @@
           "title": "Config context",
           "type": "object",
           "additionalProperties": {
-            "type": "string"
+            "type": "object"
           },
           "readOnly": true
         },
@@ -46241,7 +46241,7 @@
           "title": "Config context",
           "type": "object",
           "additionalProperties": {
-            "type": "string"
+            "type": "object"
           },
           "readOnly": true
         },


### PR DESCRIPTION
Currently go-netbox fails to parse a JSON response for config context unless it fits the very simple scheme of 'a map of strings'. 

This PR allows it to correctly map arbitrary JSON values for config context.

I am hitting this in terraform-provider-netbox - I'm adding a VM data source but it errors when reading the API response. 