### PR TITLE
Added custom fields to PrefixLength model

### DIFF
--- a/netbox/models/prefix_length.go
+++ b/netbox/models/prefix_length.go
@@ -34,6 +34,9 @@ import (
 // swagger:model PrefixLength
 type PrefixLength struct {
 
+	// Custom fields
+	CustomFields interface{} `json:"custom_fields,omitempty"`
+
 	// Prefix length
 	// Required: true
 	PrefixLength *int64 `json:"prefix_length"`

--- a/swagger.json
+++ b/swagger.json
@@ -57723,6 +57723,11 @@
         "prefix_length": {
           "title": "Prefix length",
           "type": "integer"
+        },
+        "custom_fields": {
+          "title": "Custom fields",
+          "type": "object",
+          "default": {}
         }
       }
     },

--- a/swagger.processed.json
+++ b/swagger.processed.json
@@ -62244,6 +62244,11 @@
         "prefix_length": {
           "title": "Prefix length",
           "type": "integer"
+        },
+        "custom_fields": {
+          "title": "Custom fields",
+          "type": "object",
+          "default": {}
         }
       }
     },


### PR DESCRIPTION
Added CustomFields to swagger spec, generated by make generate command.
Thanks @fbreckle)
PTAL

Required for https://github.com/e-breuninger/terraform-provider-netbox/pull/143