### PR TITLE
set omitempty = false on vlan/site for prefix

### DIFF
--- a/netbox/models/writable_prefix.go
+++ b/netbox/models/writable_prefix.go
@@ -95,7 +95,7 @@ type WritablePrefix struct {
 	Role *int64 `json:"role,omitempty"`
 
 	// Site
-	Site *int64 `json:"site,omitempty"`
+	Site *int64 `json:"site"`
 
 	// Status
 	//
@@ -115,7 +115,7 @@ type WritablePrefix struct {
 	URL strfmt.URI `json:"url,omitempty"`
 
 	// VLAN
-	Vlan *int64 `json:"vlan,omitempty"`
+	Vlan *int64 `json:"vlan"`
 
 	// VRF
 	Vrf *int64 `json:"vrf,omitempty"`

--- a/preprocess.py
+++ b/preprocess.py
@@ -131,15 +131,9 @@ for prop, prop_spec in data["definitions"]["Tag"]["properties"].items():
         prop_spec["x-omitempty"] = False
         logging.info(f"set x-omitempty = false on Tag.{prop}")
 
-# Add omitempty = false for prefix mark_utilized and is_pool
+# Add omitempty = false for prefix mark_utilized, is_pool, site_id and vlan_id
 for prop, prop_spec in data["definitions"]["WritablePrefix"]["properties"].items():
-    if prop in ["mark_utilized", "is_pool"]:
-        prop_spec["x-omitempty"] = False
-        logging.info(f"set x-omitempty = false on WritablePrefix.{prop}")
-
-# Add omitempty = false for prefix mark_utilized
-for prop, prop_spec in data["definitions"]["WritablePrefix"]["properties"].items():
-    if prop == "mark_utilized":
+    if prop in ["mark_utilized", "is_pool", "site", "vlan"]:
         prop_spec["x-omitempty"] = False
         logging.info(f"set x-omitempty = false on WritablePrefix.{prop}")
 

--- a/swagger.processed.json
+++ b/swagger.processed.json
@@ -86746,7 +86746,8 @@
         "site": {
           "title": "Site",
           "type": "integer",
-          "x-nullable": true
+          "x-nullable": true,
+          "x-omitempty": false
         },
         "vrf": {
           "title": "VRF",
@@ -86761,7 +86762,8 @@
         "vlan": {
           "title": "VLAN",
           "type": "integer",
-          "x-nullable": true
+          "x-nullable": true,
+          "x-omitempty": false
         },
         "status": {
           "title": "Status",


### PR DESCRIPTION
This PR removes the `omitempty` flag on the `Site` and `VLAN` attributes of a prefix so they can be unlinked.
I also removed a code block that looked like duplication in the preprocessing script.