### PR TITLE
:sparkles: Allow User Token's WriteEnabled field

### DIFF
--- a/netbox/models/writable_token.go
+++ b/netbox/models/writable_token.go
@@ -79,7 +79,7 @@ type WritableToken struct {
 	// Write enabled
 	//
 	// Permit create/update/delete operations using this key
-	WriteEnabled bool `json:"write_enabled,omitempty"`
+	WriteEnabled bool `json:"write_enabled"`
 }
 
 // Validate validates this writable token

--- a/preprocess.py
+++ b/preprocess.py
@@ -165,6 +165,12 @@ for prop, prop_spec in data["definitions"]["WritableIPAddress"]["properties"].it
         prop_spec["x-omitempty"] = False
         logging.info(f"set x-omitempty = false on WritableIPAddress.{prop}")
 
+# Remove omitempty = false for token write_enabled
+for prop, prop_spec in data["definitions"]["WritableToken"]["properties"].items():
+    if prop == "write_enabled":
+        prop_spec["x-omitempty"] = False
+        logging.info(f"set x-omitempty = false on WritableIPAddress.{prop}")
+
 # Delete problematic maximums (might have to be replaced with a proper value)
 for definition, definition_spec in data["definitions"].items():
     for prop, prop_spec in definition_spec["properties"].items():

--- a/swagger.processed.json
+++ b/swagger.processed.json
@@ -89891,7 +89891,8 @@
         "write_enabled": {
           "title": "Write enabled",
           "description": "Permit create/update/delete operations using this key",
-          "type": "boolean"
+          "type": "boolean",
+          "x-omitempty": false
         },
         "description": {
           "title": "Description",


### PR DESCRIPTION
By default, Netbox's REST API sets User Token's write_enabled field to true. This means that if the field is not set explicitly in the request, Netbox would automatically set it to true.

This behavior results to an inconsistency if the value is set to false and omitempty is configured in the JSON tag. This is because by default, JSON Marshaller omits false booleans. Since the field is omitted, Netbox REST API would default it to true. Hence, an inconsistency would occur.

To fix this, simply remove the omitempty tag from the writable token.

References:
- https://github.com/netbox-community/netbox/blob/21b9732f061b7e91fa77c10da66bd098510354fc/netbox/users/models.py#L216-L219