### PR TITLE
:bug: Allow clearing out site description

### DIFF
--- a/netbox/models/writable_site.go
+++ b/netbox/models/writable_site.go
@@ -57,7 +57,7 @@ type WritableSite struct {
 
 	// Description
 	// Max Length: 200
-	Description string `json:"description,omitempty"`
+	Description string `json:"description"`
 
 	// Device count
 	// Read Only: true

--- a/preprocess.py
+++ b/preprocess.py
@@ -171,6 +171,12 @@ for prop, prop_spec in data["definitions"]["WritableToken"]["properties"].items(
         prop_spec["x-omitempty"] = False
         logging.info(f"set x-omitempty = false on WritableIPAddress.{prop}")
 
+# Add omitempty = false for site description
+for prop, prop_spec in data["definitions"]["WritableSite"]["properties"].items():
+    if prop == "description":
+        prop_spec["x-omitempty"] = False
+        logging.info(f"set x-omitempty = false on WritableSite.{prop}")
+
 # Delete problematic maximums (might have to be replaced with a proper value)
 for definition, definition_spec in data["definitions"].items():
     for prop, prop_spec in definition_spec["properties"].items():

--- a/swagger.processed.json
+++ b/swagger.processed.json
@@ -83204,7 +83204,8 @@
         "description": {
           "title": "Description",
           "type": "string",
-          "maxLength": 200
+          "maxLength": 200,
+          "x-omitempty": false
         },
         "physical_address": {
           "title": "Physical address",


### PR DESCRIPTION
Currently, site that has been previously configured with a description can no longer be cleared out. Even if the terraform configuration indicates empty or nil description, the change will not be persisted to NSOT. Additionally, every time a terraform plan is run, it will always detect an update-in-place for this field.

This change fixes this behavior by removing site description's `omitempty` tag. This will allow any site descriptions to be cleared out.