### PR TITLE
Delete fields that need custom serializer handling

### DIFF
--- a/netbox/models/circuit_termination.go
+++ b/netbox/models/circuit_termination.go
@@ -77,12 +77,6 @@ type CircuitTermination struct {
 	// Format: date-time
 	LastUpdated *strfmt.DateTime `json:"last_updated,omitempty"`
 
-	//
-	// Return the appropriate serializer for the link termination model.
-	//
-	// Read Only: true
-	LinkPeers []*string `json:"link_peers"`
-
 	// Link peers type
 	// Read Only: true
 	LinkPeersType string `json:"link_peers_type,omitempty"`
@@ -500,10 +494,6 @@ func (m *CircuitTermination) ContextValidate(ctx context.Context, formats strfmt
 		res = append(res, err)
 	}
 
-	if err := m.contextValidateLinkPeers(ctx, formats); err != nil {
-		res = append(res, err)
-	}
-
 	if err := m.contextValidateLinkPeersType(ctx, formats); err != nil {
 		res = append(res, err)
 	}
@@ -610,15 +600,6 @@ func (m *CircuitTermination) contextValidateID(ctx context.Context, formats strf
 func (m *CircuitTermination) contextValidateLastUpdated(ctx context.Context, formats strfmt.Registry) error {
 
 	if err := validate.ReadOnly(ctx, "last_updated", "body", m.LastUpdated); err != nil {
-		return err
-	}
-
-	return nil
-}
-
-func (m *CircuitTermination) contextValidateLinkPeers(ctx context.Context, formats strfmt.Registry) error {
-
-	if err := validate.ReadOnly(ctx, "link_peers", "body", []*string(m.LinkPeers)); err != nil {
 		return err
 	}
 

--- a/netbox/models/console_port.go
+++ b/netbox/models/console_port.go
@@ -48,12 +48,6 @@ type ConsolePort struct {
 	// Min Length: 1
 	CableEnd string `json:"cable_end,omitempty"`
 
-	//
-	// Return the appropriate serializer for the type of connected object.
-	//
-	// Read Only: true
-	ConnectedEndpoints []*string `json:"connected_endpoints"`
-
 	// Connected endpoints reachable
 	// Read Only: true
 	ConnectedEndpointsReachable *bool `json:"connected_endpoints_reachable,omitempty"`
@@ -96,12 +90,6 @@ type ConsolePort struct {
 	// Read Only: true
 	// Format: date-time
 	LastUpdated *strfmt.DateTime `json:"last_updated,omitempty"`
-
-	//
-	// Return the appropriate serializer for the link termination model.
-	//
-	// Read Only: true
-	LinkPeers []*string `json:"link_peers"`
 
 	// Link peers type
 	// Read Only: true
@@ -425,10 +413,6 @@ func (m *ConsolePort) ContextValidate(ctx context.Context, formats strfmt.Regist
 		res = append(res, err)
 	}
 
-	if err := m.contextValidateConnectedEndpoints(ctx, formats); err != nil {
-		res = append(res, err)
-	}
-
 	if err := m.contextValidateConnectedEndpointsReachable(ctx, formats); err != nil {
 		res = append(res, err)
 	}
@@ -454,10 +438,6 @@ func (m *ConsolePort) ContextValidate(ctx context.Context, formats strfmt.Regist
 	}
 
 	if err := m.contextValidateLastUpdated(ctx, formats); err != nil {
-		res = append(res, err)
-	}
-
-	if err := m.contextValidateLinkPeers(ctx, formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -519,15 +499,6 @@ func (m *ConsolePort) contextValidateCable(ctx context.Context, formats strfmt.R
 func (m *ConsolePort) contextValidateCableEnd(ctx context.Context, formats strfmt.Registry) error {
 
 	if err := validate.ReadOnly(ctx, "cable_end", "body", string(m.CableEnd)); err != nil {
-		return err
-	}
-
-	return nil
-}
-
-func (m *ConsolePort) contextValidateConnectedEndpoints(ctx context.Context, formats strfmt.Registry) error {
-
-	if err := validate.ReadOnly(ctx, "connected_endpoints", "body", []*string(m.ConnectedEndpoints)); err != nil {
 		return err
 	}
 
@@ -598,15 +569,6 @@ func (m *ConsolePort) contextValidateID(ctx context.Context, formats strfmt.Regi
 func (m *ConsolePort) contextValidateLastUpdated(ctx context.Context, formats strfmt.Registry) error {
 
 	if err := validate.ReadOnly(ctx, "last_updated", "body", m.LastUpdated); err != nil {
-		return err
-	}
-
-	return nil
-}
-
-func (m *ConsolePort) contextValidateLinkPeers(ctx context.Context, formats strfmt.Registry) error {
-
-	if err := validate.ReadOnly(ctx, "link_peers", "body", []*string(m.LinkPeers)); err != nil {
 		return err
 	}
 

--- a/netbox/models/console_server_port.go
+++ b/netbox/models/console_server_port.go
@@ -48,12 +48,6 @@ type ConsoleServerPort struct {
 	// Min Length: 1
 	CableEnd string `json:"cable_end,omitempty"`
 
-	//
-	// Return the appropriate serializer for the type of connected object.
-	//
-	// Read Only: true
-	ConnectedEndpoints []*string `json:"connected_endpoints"`
-
 	// Connected endpoints reachable
 	// Read Only: true
 	ConnectedEndpointsReachable *bool `json:"connected_endpoints_reachable,omitempty"`
@@ -96,12 +90,6 @@ type ConsoleServerPort struct {
 	// Read Only: true
 	// Format: date-time
 	LastUpdated *strfmt.DateTime `json:"last_updated,omitempty"`
-
-	//
-	// Return the appropriate serializer for the link termination model.
-	//
-	// Read Only: true
-	LinkPeers []*string `json:"link_peers"`
 
 	// Link peers type
 	// Read Only: true
@@ -425,10 +413,6 @@ func (m *ConsoleServerPort) ContextValidate(ctx context.Context, formats strfmt.
 		res = append(res, err)
 	}
 
-	if err := m.contextValidateConnectedEndpoints(ctx, formats); err != nil {
-		res = append(res, err)
-	}
-
 	if err := m.contextValidateConnectedEndpointsReachable(ctx, formats); err != nil {
 		res = append(res, err)
 	}
@@ -454,10 +438,6 @@ func (m *ConsoleServerPort) ContextValidate(ctx context.Context, formats strfmt.
 	}
 
 	if err := m.contextValidateLastUpdated(ctx, formats); err != nil {
-		res = append(res, err)
-	}
-
-	if err := m.contextValidateLinkPeers(ctx, formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -519,15 +499,6 @@ func (m *ConsoleServerPort) contextValidateCable(ctx context.Context, formats st
 func (m *ConsoleServerPort) contextValidateCableEnd(ctx context.Context, formats strfmt.Registry) error {
 
 	if err := validate.ReadOnly(ctx, "cable_end", "body", string(m.CableEnd)); err != nil {
-		return err
-	}
-
-	return nil
-}
-
-func (m *ConsoleServerPort) contextValidateConnectedEndpoints(ctx context.Context, formats strfmt.Registry) error {
-
-	if err := validate.ReadOnly(ctx, "connected_endpoints", "body", []*string(m.ConnectedEndpoints)); err != nil {
 		return err
 	}
 
@@ -598,15 +569,6 @@ func (m *ConsoleServerPort) contextValidateID(ctx context.Context, formats strfm
 func (m *ConsoleServerPort) contextValidateLastUpdated(ctx context.Context, formats strfmt.Registry) error {
 
 	if err := validate.ReadOnly(ctx, "last_updated", "body", m.LastUpdated); err != nil {
-		return err
-	}
-
-	return nil
-}
-
-func (m *ConsoleServerPort) contextValidateLinkPeers(ctx context.Context, formats strfmt.Registry) error {
-
-	if err := validate.ReadOnly(ctx, "link_peers", "body", []*string(m.LinkPeers)); err != nil {
 		return err
 	}
 

--- a/netbox/models/front_port.go
+++ b/netbox/models/front_port.go
@@ -88,12 +88,6 @@ type FrontPort struct {
 	// Format: date-time
 	LastUpdated *strfmt.DateTime `json:"last_updated,omitempty"`
 
-	//
-	// Return the appropriate serializer for the link termination model.
-	//
-	// Read Only: true
-	LinkPeers []*string `json:"link_peers"`
-
 	// Link peers type
 	// Read Only: true
 	LinkPeersType string `json:"link_peers_type,omitempty"`
@@ -485,10 +479,6 @@ func (m *FrontPort) ContextValidate(ctx context.Context, formats strfmt.Registry
 		res = append(res, err)
 	}
 
-	if err := m.contextValidateLinkPeers(ctx, formats); err != nil {
-		res = append(res, err)
-	}
-
 	if err := m.contextValidateLinkPeersType(ctx, formats); err != nil {
 		res = append(res, err)
 	}
@@ -599,15 +589,6 @@ func (m *FrontPort) contextValidateID(ctx context.Context, formats strfmt.Regist
 func (m *FrontPort) contextValidateLastUpdated(ctx context.Context, formats strfmt.Registry) error {
 
 	if err := validate.ReadOnly(ctx, "last_updated", "body", m.LastUpdated); err != nil {
-		return err
-	}
-
-	return nil
-}
-
-func (m *FrontPort) contextValidateLinkPeers(ctx context.Context, formats strfmt.Registry) error {
-
-	if err := validate.ReadOnly(ctx, "link_peers", "body", []*string(m.LinkPeers)); err != nil {
 		return err
 	}
 

--- a/netbox/models/interface.go
+++ b/netbox/models/interface.go
@@ -51,12 +51,6 @@ type Interface struct {
 	// Min Length: 1
 	CableEnd string `json:"cable_end,omitempty"`
 
-	//
-	// Return the appropriate serializer for the type of connected object.
-	//
-	// Read Only: true
-	ConnectedEndpoints []*string `json:"connected_endpoints"`
-
 	// Connected endpoints reachable
 	// Read Only: true
 	ConnectedEndpointsReachable *bool `json:"connected_endpoints_reachable,omitempty"`
@@ -119,12 +113,6 @@ type Interface struct {
 	// Read Only: true
 	// Format: date-time
 	LastUpdated *strfmt.DateTime `json:"last_updated,omitempty"`
-
-	//
-	// Return the appropriate serializer for the link termination model.
-	//
-	// Read Only: true
-	LinkPeers []*string `json:"link_peers"`
 
 	// Link peers type
 	// Read Only: true
@@ -962,10 +950,6 @@ func (m *Interface) ContextValidate(ctx context.Context, formats strfmt.Registry
 		res = append(res, err)
 	}
 
-	if err := m.contextValidateConnectedEndpoints(ctx, formats); err != nil {
-		res = append(res, err)
-	}
-
 	if err := m.contextValidateConnectedEndpointsReachable(ctx, formats); err != nil {
 		res = append(res, err)
 	}
@@ -1011,10 +995,6 @@ func (m *Interface) ContextValidate(ctx context.Context, formats strfmt.Registry
 	}
 
 	if err := m.contextValidateLastUpdated(ctx, formats); err != nil {
-		res = append(res, err)
-	}
-
-	if err := m.contextValidateLinkPeers(ctx, formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -1136,15 +1116,6 @@ func (m *Interface) contextValidateCable(ctx context.Context, formats strfmt.Reg
 func (m *Interface) contextValidateCableEnd(ctx context.Context, formats strfmt.Registry) error {
 
 	if err := validate.ReadOnly(ctx, "cable_end", "body", string(m.CableEnd)); err != nil {
-		return err
-	}
-
-	return nil
-}
-
-func (m *Interface) contextValidateConnectedEndpoints(ctx context.Context, formats strfmt.Registry) error {
-
-	if err := validate.ReadOnly(ctx, "connected_endpoints", "body", []*string(m.ConnectedEndpoints)); err != nil {
 		return err
 	}
 
@@ -1281,15 +1252,6 @@ func (m *Interface) contextValidateLag(ctx context.Context, formats strfmt.Regis
 func (m *Interface) contextValidateLastUpdated(ctx context.Context, formats strfmt.Registry) error {
 
 	if err := validate.ReadOnly(ctx, "last_updated", "body", m.LastUpdated); err != nil {
-		return err
-	}
-
-	return nil
-}
-
-func (m *Interface) contextValidateLinkPeers(ctx context.Context, formats strfmt.Registry) error {
-
-	if err := validate.ReadOnly(ctx, "link_peers", "body", []*string(m.LinkPeers)); err != nil {
 		return err
 	}
 

--- a/netbox/models/power_feed.go
+++ b/netbox/models/power_feed.go
@@ -56,12 +56,6 @@ type PowerFeed struct {
 	// Comments
 	Comments string `json:"comments,omitempty"`
 
-	//
-	// Return the appropriate serializer for the type of connected object.
-	//
-	// Read Only: true
-	ConnectedEndpoints []*string `json:"connected_endpoints"`
-
 	// Connected endpoints reachable
 	// Read Only: true
 	ConnectedEndpointsReachable *bool `json:"connected_endpoints_reachable,omitempty"`
@@ -94,12 +88,6 @@ type PowerFeed struct {
 	// Read Only: true
 	// Format: date-time
 	LastUpdated *strfmt.DateTime `json:"last_updated,omitempty"`
-
-	//
-	// Return the appropriate serializer for the link termination model.
-	//
-	// Read Only: true
-	LinkPeers []*string `json:"link_peers"`
 
 	// Link peers type
 	// Read Only: true
@@ -535,10 +523,6 @@ func (m *PowerFeed) ContextValidate(ctx context.Context, formats strfmt.Registry
 		res = append(res, err)
 	}
 
-	if err := m.contextValidateConnectedEndpoints(ctx, formats); err != nil {
-		res = append(res, err)
-	}
-
 	if err := m.contextValidateConnectedEndpointsReachable(ctx, formats); err != nil {
 		res = append(res, err)
 	}
@@ -560,10 +544,6 @@ func (m *PowerFeed) ContextValidate(ctx context.Context, formats strfmt.Registry
 	}
 
 	if err := m.contextValidateLastUpdated(ctx, formats); err != nil {
-		res = append(res, err)
-	}
-
-	if err := m.contextValidateLinkPeers(ctx, formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -643,15 +623,6 @@ func (m *PowerFeed) contextValidateCableEnd(ctx context.Context, formats strfmt.
 	return nil
 }
 
-func (m *PowerFeed) contextValidateConnectedEndpoints(ctx context.Context, formats strfmt.Registry) error {
-
-	if err := validate.ReadOnly(ctx, "connected_endpoints", "body", []*string(m.ConnectedEndpoints)); err != nil {
-		return err
-	}
-
-	return nil
-}
-
 func (m *PowerFeed) contextValidateConnectedEndpointsReachable(ctx context.Context, formats strfmt.Registry) error {
 
 	if err := validate.ReadOnly(ctx, "connected_endpoints_reachable", "body", m.ConnectedEndpointsReachable); err != nil {
@@ -700,15 +671,6 @@ func (m *PowerFeed) contextValidateID(ctx context.Context, formats strfmt.Regist
 func (m *PowerFeed) contextValidateLastUpdated(ctx context.Context, formats strfmt.Registry) error {
 
 	if err := validate.ReadOnly(ctx, "last_updated", "body", m.LastUpdated); err != nil {
-		return err
-	}
-
-	return nil
-}
-
-func (m *PowerFeed) contextValidateLinkPeers(ctx context.Context, formats strfmt.Registry) error {
-
-	if err := validate.ReadOnly(ctx, "link_peers", "body", []*string(m.LinkPeers)); err != nil {
 		return err
 	}
 

--- a/netbox/models/power_outlet.go
+++ b/netbox/models/power_outlet.go
@@ -48,12 +48,6 @@ type PowerOutlet struct {
 	// Min Length: 1
 	CableEnd string `json:"cable_end,omitempty"`
 
-	//
-	// Return the appropriate serializer for the type of connected object.
-	//
-	// Read Only: true
-	ConnectedEndpoints []*string `json:"connected_endpoints"`
-
 	// Connected endpoints reachable
 	// Read Only: true
 	ConnectedEndpointsReachable *bool `json:"connected_endpoints_reachable,omitempty"`
@@ -99,12 +93,6 @@ type PowerOutlet struct {
 	// Read Only: true
 	// Format: date-time
 	LastUpdated *strfmt.DateTime `json:"last_updated,omitempty"`
-
-	//
-	// Return the appropriate serializer for the link termination model.
-	//
-	// Read Only: true
-	LinkPeers []*string `json:"link_peers"`
 
 	// Link peers type
 	// Read Only: true
@@ -451,10 +439,6 @@ func (m *PowerOutlet) ContextValidate(ctx context.Context, formats strfmt.Regist
 		res = append(res, err)
 	}
 
-	if err := m.contextValidateConnectedEndpoints(ctx, formats); err != nil {
-		res = append(res, err)
-	}
-
 	if err := m.contextValidateConnectedEndpointsReachable(ctx, formats); err != nil {
 		res = append(res, err)
 	}
@@ -484,10 +468,6 @@ func (m *PowerOutlet) ContextValidate(ctx context.Context, formats strfmt.Regist
 	}
 
 	if err := m.contextValidateLastUpdated(ctx, formats); err != nil {
-		res = append(res, err)
-	}
-
-	if err := m.contextValidateLinkPeers(ctx, formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -549,15 +529,6 @@ func (m *PowerOutlet) contextValidateCable(ctx context.Context, formats strfmt.R
 func (m *PowerOutlet) contextValidateCableEnd(ctx context.Context, formats strfmt.Registry) error {
 
 	if err := validate.ReadOnly(ctx, "cable_end", "body", string(m.CableEnd)); err != nil {
-		return err
-	}
-
-	return nil
-}
-
-func (m *PowerOutlet) contextValidateConnectedEndpoints(ctx context.Context, formats strfmt.Registry) error {
-
-	if err := validate.ReadOnly(ctx, "connected_endpoints", "body", []*string(m.ConnectedEndpoints)); err != nil {
 		return err
 	}
 
@@ -644,15 +615,6 @@ func (m *PowerOutlet) contextValidateID(ctx context.Context, formats strfmt.Regi
 func (m *PowerOutlet) contextValidateLastUpdated(ctx context.Context, formats strfmt.Registry) error {
 
 	if err := validate.ReadOnly(ctx, "last_updated", "body", m.LastUpdated); err != nil {
-		return err
-	}
-
-	return nil
-}
-
-func (m *PowerOutlet) contextValidateLinkPeers(ctx context.Context, formats strfmt.Registry) error {
-
-	if err := validate.ReadOnly(ctx, "link_peers", "body", []*string(m.LinkPeers)); err != nil {
 		return err
 	}
 

--- a/netbox/models/power_port.go
+++ b/netbox/models/power_port.go
@@ -55,12 +55,6 @@ type PowerPort struct {
 	// Min Length: 1
 	CableEnd string `json:"cable_end,omitempty"`
 
-	//
-	// Return the appropriate serializer for the type of connected object.
-	//
-	// Read Only: true
-	ConnectedEndpoints []*string `json:"connected_endpoints"`
-
 	// Connected endpoints reachable
 	// Read Only: true
 	ConnectedEndpointsReachable *bool `json:"connected_endpoints_reachable,omitempty"`
@@ -103,12 +97,6 @@ type PowerPort struct {
 	// Read Only: true
 	// Format: date-time
 	LastUpdated *strfmt.DateTime `json:"last_updated,omitempty"`
-
-	//
-	// Return the appropriate serializer for the link termination model.
-	//
-	// Read Only: true
-	LinkPeers []*string `json:"link_peers"`
 
 	// Link peers type
 	// Read Only: true
@@ -453,10 +441,6 @@ func (m *PowerPort) ContextValidate(ctx context.Context, formats strfmt.Registry
 		res = append(res, err)
 	}
 
-	if err := m.contextValidateConnectedEndpoints(ctx, formats); err != nil {
-		res = append(res, err)
-	}
-
 	if err := m.contextValidateConnectedEndpointsReachable(ctx, formats); err != nil {
 		res = append(res, err)
 	}
@@ -482,10 +466,6 @@ func (m *PowerPort) ContextValidate(ctx context.Context, formats strfmt.Registry
 	}
 
 	if err := m.contextValidateLastUpdated(ctx, formats); err != nil {
-		res = append(res, err)
-	}
-
-	if err := m.contextValidateLinkPeers(ctx, formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -543,15 +523,6 @@ func (m *PowerPort) contextValidateCable(ctx context.Context, formats strfmt.Reg
 func (m *PowerPort) contextValidateCableEnd(ctx context.Context, formats strfmt.Registry) error {
 
 	if err := validate.ReadOnly(ctx, "cable_end", "body", string(m.CableEnd)); err != nil {
-		return err
-	}
-
-	return nil
-}
-
-func (m *PowerPort) contextValidateConnectedEndpoints(ctx context.Context, formats strfmt.Registry) error {
-
-	if err := validate.ReadOnly(ctx, "connected_endpoints", "body", []*string(m.ConnectedEndpoints)); err != nil {
 		return err
 	}
 
@@ -622,15 +593,6 @@ func (m *PowerPort) contextValidateID(ctx context.Context, formats strfmt.Regist
 func (m *PowerPort) contextValidateLastUpdated(ctx context.Context, formats strfmt.Registry) error {
 
 	if err := validate.ReadOnly(ctx, "last_updated", "body", m.LastUpdated); err != nil {
-		return err
-	}
-
-	return nil
-}
-
-func (m *PowerPort) contextValidateLinkPeers(ctx context.Context, formats strfmt.Registry) error {
-
-	if err := validate.ReadOnly(ctx, "link_peers", "body", []*string(m.LinkPeers)); err != nil {
 		return err
 	}
 

--- a/netbox/models/rear_port.go
+++ b/netbox/models/rear_port.go
@@ -88,12 +88,6 @@ type RearPort struct {
 	// Format: date-time
 	LastUpdated *strfmt.DateTime `json:"last_updated,omitempty"`
 
-	//
-	// Return the appropriate serializer for the link termination model.
-	//
-	// Read Only: true
-	LinkPeers []*string `json:"link_peers"`
-
 	// Link peers type
 	// Read Only: true
 	LinkPeersType string `json:"link_peers_type,omitempty"`
@@ -457,10 +451,6 @@ func (m *RearPort) ContextValidate(ctx context.Context, formats strfmt.Registry)
 		res = append(res, err)
 	}
 
-	if err := m.contextValidateLinkPeers(ctx, formats); err != nil {
-		res = append(res, err)
-	}
-
 	if err := m.contextValidateLinkPeersType(ctx, formats); err != nil {
 		res = append(res, err)
 	}
@@ -567,15 +557,6 @@ func (m *RearPort) contextValidateID(ctx context.Context, formats strfmt.Registr
 func (m *RearPort) contextValidateLastUpdated(ctx context.Context, formats strfmt.Registry) error {
 
 	if err := validate.ReadOnly(ctx, "last_updated", "body", m.LastUpdated); err != nil {
-		return err
-	}
-
-	return nil
-}
-
-func (m *RearPort) contextValidateLinkPeers(ctx context.Context, formats strfmt.Registry) error {
-
-	if err := validate.ReadOnly(ctx, "link_peers", "body", []*string(m.LinkPeers)); err != nil {
 		return err
 	}
 

--- a/netbox/models/writable_circuit_termination.go
+++ b/netbox/models/writable_circuit_termination.go
@@ -77,12 +77,6 @@ type WritableCircuitTermination struct {
 	// Format: date-time
 	LastUpdated *strfmt.DateTime `json:"last_updated,omitempty"`
 
-	//
-	// Return the appropriate serializer for the link termination model.
-	//
-	// Read Only: true
-	LinkPeers []*string `json:"link_peers"`
-
 	// Link peers type
 	// Read Only: true
 	LinkPeersType string `json:"link_peers_type,omitempty"`
@@ -439,10 +433,6 @@ func (m *WritableCircuitTermination) ContextValidate(ctx context.Context, format
 		res = append(res, err)
 	}
 
-	if err := m.contextValidateLinkPeers(ctx, formats); err != nil {
-		res = append(res, err)
-	}
-
 	if err := m.contextValidateLinkPeersType(ctx, formats); err != nil {
 		res = append(res, err)
 	}
@@ -525,15 +515,6 @@ func (m *WritableCircuitTermination) contextValidateID(ctx context.Context, form
 func (m *WritableCircuitTermination) contextValidateLastUpdated(ctx context.Context, formats strfmt.Registry) error {
 
 	if err := validate.ReadOnly(ctx, "last_updated", "body", m.LastUpdated); err != nil {
-		return err
-	}
-
-	return nil
-}
-
-func (m *WritableCircuitTermination) contextValidateLinkPeers(ctx context.Context, formats strfmt.Registry) error {
-
-	if err := validate.ReadOnly(ctx, "link_peers", "body", []*string(m.LinkPeers)); err != nil {
 		return err
 	}
 

--- a/netbox/models/writable_console_port.go
+++ b/netbox/models/writable_console_port.go
@@ -48,12 +48,6 @@ type WritableConsolePort struct {
 	// Min Length: 1
 	CableEnd string `json:"cable_end,omitempty"`
 
-	//
-	// Return the appropriate serializer for the type of connected object.
-	//
-	// Read Only: true
-	ConnectedEndpoints []*string `json:"connected_endpoints"`
-
 	// Connected endpoints reachable
 	// Read Only: true
 	ConnectedEndpointsReachable *bool `json:"connected_endpoints_reachable,omitempty"`
@@ -96,12 +90,6 @@ type WritableConsolePort struct {
 	// Read Only: true
 	// Format: date-time
 	LastUpdated *strfmt.DateTime `json:"last_updated,omitempty"`
-
-	//
-	// Return the appropriate serializer for the link termination model.
-	//
-	// Read Only: true
-	LinkPeers []*string `json:"link_peers"`
 
 	// Link peers type
 	// Read Only: true
@@ -473,10 +461,6 @@ func (m *WritableConsolePort) ContextValidate(ctx context.Context, formats strfm
 		res = append(res, err)
 	}
 
-	if err := m.contextValidateConnectedEndpoints(ctx, formats); err != nil {
-		res = append(res, err)
-	}
-
 	if err := m.contextValidateConnectedEndpointsReachable(ctx, formats); err != nil {
 		res = append(res, err)
 	}
@@ -498,10 +482,6 @@ func (m *WritableConsolePort) ContextValidate(ctx context.Context, formats strfm
 	}
 
 	if err := m.contextValidateLastUpdated(ctx, formats); err != nil {
-		res = append(res, err)
-	}
-
-	if err := m.contextValidateLinkPeers(ctx, formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -557,15 +537,6 @@ func (m *WritableConsolePort) contextValidateCableEnd(ctx context.Context, forma
 	return nil
 }
 
-func (m *WritableConsolePort) contextValidateConnectedEndpoints(ctx context.Context, formats strfmt.Registry) error {
-
-	if err := validate.ReadOnly(ctx, "connected_endpoints", "body", []*string(m.ConnectedEndpoints)); err != nil {
-		return err
-	}
-
-	return nil
-}
-
 func (m *WritableConsolePort) contextValidateConnectedEndpointsReachable(ctx context.Context, formats strfmt.Registry) error {
 
 	if err := validate.ReadOnly(ctx, "connected_endpoints_reachable", "body", m.ConnectedEndpointsReachable); err != nil {
@@ -614,15 +585,6 @@ func (m *WritableConsolePort) contextValidateID(ctx context.Context, formats str
 func (m *WritableConsolePort) contextValidateLastUpdated(ctx context.Context, formats strfmt.Registry) error {
 
 	if err := validate.ReadOnly(ctx, "last_updated", "body", m.LastUpdated); err != nil {
-		return err
-	}
-
-	return nil
-}
-
-func (m *WritableConsolePort) contextValidateLinkPeers(ctx context.Context, formats strfmt.Registry) error {
-
-	if err := validate.ReadOnly(ctx, "link_peers", "body", []*string(m.LinkPeers)); err != nil {
 		return err
 	}
 

--- a/netbox/models/writable_console_server_port.go
+++ b/netbox/models/writable_console_server_port.go
@@ -48,12 +48,6 @@ type WritableConsoleServerPort struct {
 	// Min Length: 1
 	CableEnd string `json:"cable_end,omitempty"`
 
-	//
-	// Return the appropriate serializer for the type of connected object.
-	//
-	// Read Only: true
-	ConnectedEndpoints []*string `json:"connected_endpoints"`
-
 	// Connected endpoints reachable
 	// Read Only: true
 	ConnectedEndpointsReachable *bool `json:"connected_endpoints_reachable,omitempty"`
@@ -96,12 +90,6 @@ type WritableConsoleServerPort struct {
 	// Read Only: true
 	// Format: date-time
 	LastUpdated *strfmt.DateTime `json:"last_updated,omitempty"`
-
-	//
-	// Return the appropriate serializer for the link termination model.
-	//
-	// Read Only: true
-	LinkPeers []*string `json:"link_peers"`
 
 	// Link peers type
 	// Read Only: true
@@ -473,10 +461,6 @@ func (m *WritableConsoleServerPort) ContextValidate(ctx context.Context, formats
 		res = append(res, err)
 	}
 
-	if err := m.contextValidateConnectedEndpoints(ctx, formats); err != nil {
-		res = append(res, err)
-	}
-
 	if err := m.contextValidateConnectedEndpointsReachable(ctx, formats); err != nil {
 		res = append(res, err)
 	}
@@ -498,10 +482,6 @@ func (m *WritableConsoleServerPort) ContextValidate(ctx context.Context, formats
 	}
 
 	if err := m.contextValidateLastUpdated(ctx, formats); err != nil {
-		res = append(res, err)
-	}
-
-	if err := m.contextValidateLinkPeers(ctx, formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -557,15 +537,6 @@ func (m *WritableConsoleServerPort) contextValidateCableEnd(ctx context.Context,
 	return nil
 }
 
-func (m *WritableConsoleServerPort) contextValidateConnectedEndpoints(ctx context.Context, formats strfmt.Registry) error {
-
-	if err := validate.ReadOnly(ctx, "connected_endpoints", "body", []*string(m.ConnectedEndpoints)); err != nil {
-		return err
-	}
-
-	return nil
-}
-
 func (m *WritableConsoleServerPort) contextValidateConnectedEndpointsReachable(ctx context.Context, formats strfmt.Registry) error {
 
 	if err := validate.ReadOnly(ctx, "connected_endpoints_reachable", "body", m.ConnectedEndpointsReachable); err != nil {
@@ -614,15 +585,6 @@ func (m *WritableConsoleServerPort) contextValidateID(ctx context.Context, forma
 func (m *WritableConsoleServerPort) contextValidateLastUpdated(ctx context.Context, formats strfmt.Registry) error {
 
 	if err := validate.ReadOnly(ctx, "last_updated", "body", m.LastUpdated); err != nil {
-		return err
-	}
-
-	return nil
-}
-
-func (m *WritableConsoleServerPort) contextValidateLinkPeers(ctx context.Context, formats strfmt.Registry) error {
-
-	if err := validate.ReadOnly(ctx, "link_peers", "body", []*string(m.LinkPeers)); err != nil {
 		return err
 	}
 

--- a/netbox/models/writable_front_port.go
+++ b/netbox/models/writable_front_port.go
@@ -88,12 +88,6 @@ type WritableFrontPort struct {
 	// Format: date-time
 	LastUpdated *strfmt.DateTime `json:"last_updated,omitempty"`
 
-	//
-	// Return the appropriate serializer for the link termination model.
-	//
-	// Read Only: true
-	LinkPeers []*string `json:"link_peers"`
-
 	// Link peers type
 	// Read Only: true
 	LinkPeersType string `json:"link_peers_type,omitempty"`
@@ -583,10 +577,6 @@ func (m *WritableFrontPort) ContextValidate(ctx context.Context, formats strfmt.
 		res = append(res, err)
 	}
 
-	if err := m.contextValidateLinkPeers(ctx, formats); err != nil {
-		res = append(res, err)
-	}
-
 	if err := m.contextValidateLinkPeersType(ctx, formats); err != nil {
 		res = append(res, err)
 	}
@@ -669,15 +659,6 @@ func (m *WritableFrontPort) contextValidateID(ctx context.Context, formats strfm
 func (m *WritableFrontPort) contextValidateLastUpdated(ctx context.Context, formats strfmt.Registry) error {
 
 	if err := validate.ReadOnly(ctx, "last_updated", "body", m.LastUpdated); err != nil {
-		return err
-	}
-
-	return nil
-}
-
-func (m *WritableFrontPort) contextValidateLinkPeers(ctx context.Context, formats strfmt.Registry) error {
-
-	if err := validate.ReadOnly(ctx, "link_peers", "body", []*string(m.LinkPeers)); err != nil {
 		return err
 	}
 

--- a/netbox/models/writable_interface.go
+++ b/netbox/models/writable_interface.go
@@ -51,12 +51,6 @@ type WritableInterface struct {
 	// Min Length: 1
 	CableEnd string `json:"cable_end,omitempty"`
 
-	//
-	// Return the appropriate serializer for the type of connected object.
-	//
-	// Read Only: true
-	ConnectedEndpoints []*string `json:"connected_endpoints"`
-
 	// Connected endpoints reachable
 	// Read Only: true
 	ConnectedEndpointsReachable *bool `json:"connected_endpoints_reachable,omitempty"`
@@ -121,12 +115,6 @@ type WritableInterface struct {
 	// Read Only: true
 	// Format: date-time
 	LastUpdated *strfmt.DateTime `json:"last_updated,omitempty"`
-
-	//
-	// Return the appropriate serializer for the link termination model.
-	//
-	// Read Only: true
-	LinkPeers []*string `json:"link_peers"`
 
 	// Link peers type
 	// Read Only: true
@@ -1801,10 +1789,6 @@ func (m *WritableInterface) ContextValidate(ctx context.Context, formats strfmt.
 		res = append(res, err)
 	}
 
-	if err := m.contextValidateConnectedEndpoints(ctx, formats); err != nil {
-		res = append(res, err)
-	}
-
 	if err := m.contextValidateConnectedEndpointsReachable(ctx, formats); err != nil {
 		res = append(res, err)
 	}
@@ -1838,10 +1822,6 @@ func (m *WritableInterface) ContextValidate(ctx context.Context, formats strfmt.
 	}
 
 	if err := m.contextValidateLastUpdated(ctx, formats); err != nil {
-		res = append(res, err)
-	}
-
-	if err := m.contextValidateLinkPeers(ctx, formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -1891,15 +1871,6 @@ func (m *WritableInterface) contextValidateCable(ctx context.Context, formats st
 func (m *WritableInterface) contextValidateCableEnd(ctx context.Context, formats strfmt.Registry) error {
 
 	if err := validate.ReadOnly(ctx, "cable_end", "body", string(m.CableEnd)); err != nil {
-		return err
-	}
-
-	return nil
-}
-
-func (m *WritableInterface) contextValidateConnectedEndpoints(ctx context.Context, formats strfmt.Registry) error {
-
-	if err := validate.ReadOnly(ctx, "connected_endpoints", "body", []*string(m.ConnectedEndpoints)); err != nil {
 		return err
 	}
 
@@ -1981,15 +1952,6 @@ func (m *WritableInterface) contextValidateL2vpnTermination(ctx context.Context,
 func (m *WritableInterface) contextValidateLastUpdated(ctx context.Context, formats strfmt.Registry) error {
 
 	if err := validate.ReadOnly(ctx, "last_updated", "body", m.LastUpdated); err != nil {
-		return err
-	}
-
-	return nil
-}
-
-func (m *WritableInterface) contextValidateLinkPeers(ctx context.Context, formats strfmt.Registry) error {
-
-	if err := validate.ReadOnly(ctx, "link_peers", "body", []*string(m.LinkPeers)); err != nil {
 		return err
 	}
 

--- a/netbox/models/writable_power_feed.go
+++ b/netbox/models/writable_power_feed.go
@@ -56,12 +56,6 @@ type WritablePowerFeed struct {
 	// Comments
 	Comments string `json:"comments,omitempty"`
 
-	//
-	// Return the appropriate serializer for the type of connected object.
-	//
-	// Read Only: true
-	ConnectedEndpoints []*string `json:"connected_endpoints"`
-
 	// Connected endpoints reachable
 	// Read Only: true
 	ConnectedEndpointsReachable *bool `json:"connected_endpoints_reachable,omitempty"`
@@ -94,12 +88,6 @@ type WritablePowerFeed struct {
 	// Read Only: true
 	// Format: date-time
 	LastUpdated *strfmt.DateTime `json:"last_updated,omitempty"`
-
-	//
-	// Return the appropriate serializer for the link termination model.
-	//
-	// Read Only: true
-	LinkPeers []*string `json:"link_peers"`
 
 	// Link peers type
 	// Read Only: true
@@ -603,10 +591,6 @@ func (m *WritablePowerFeed) ContextValidate(ctx context.Context, formats strfmt.
 		res = append(res, err)
 	}
 
-	if err := m.contextValidateConnectedEndpoints(ctx, formats); err != nil {
-		res = append(res, err)
-	}
-
 	if err := m.contextValidateConnectedEndpointsReachable(ctx, formats); err != nil {
 		res = append(res, err)
 	}
@@ -628,10 +612,6 @@ func (m *WritablePowerFeed) ContextValidate(ctx context.Context, formats strfmt.
 	}
 
 	if err := m.contextValidateLastUpdated(ctx, formats); err != nil {
-		res = append(res, err)
-	}
-
-	if err := m.contextValidateLinkPeers(ctx, formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -687,15 +667,6 @@ func (m *WritablePowerFeed) contextValidateCableEnd(ctx context.Context, formats
 	return nil
 }
 
-func (m *WritablePowerFeed) contextValidateConnectedEndpoints(ctx context.Context, formats strfmt.Registry) error {
-
-	if err := validate.ReadOnly(ctx, "connected_endpoints", "body", []*string(m.ConnectedEndpoints)); err != nil {
-		return err
-	}
-
-	return nil
-}
-
 func (m *WritablePowerFeed) contextValidateConnectedEndpointsReachable(ctx context.Context, formats strfmt.Registry) error {
 
 	if err := validate.ReadOnly(ctx, "connected_endpoints_reachable", "body", m.ConnectedEndpointsReachable); err != nil {
@@ -744,15 +715,6 @@ func (m *WritablePowerFeed) contextValidateID(ctx context.Context, formats strfm
 func (m *WritablePowerFeed) contextValidateLastUpdated(ctx context.Context, formats strfmt.Registry) error {
 
 	if err := validate.ReadOnly(ctx, "last_updated", "body", m.LastUpdated); err != nil {
-		return err
-	}
-
-	return nil
-}
-
-func (m *WritablePowerFeed) contextValidateLinkPeers(ctx context.Context, formats strfmt.Registry) error {
-
-	if err := validate.ReadOnly(ctx, "link_peers", "body", []*string(m.LinkPeers)); err != nil {
 		return err
 	}
 

--- a/netbox/models/writable_power_outlet.go
+++ b/netbox/models/writable_power_outlet.go
@@ -48,12 +48,6 @@ type WritablePowerOutlet struct {
 	// Min Length: 1
 	CableEnd string `json:"cable_end,omitempty"`
 
-	//
-	// Return the appropriate serializer for the type of connected object.
-	//
-	// Read Only: true
-	ConnectedEndpoints []*string `json:"connected_endpoints"`
-
 	// Connected endpoints reachable
 	// Read Only: true
 	ConnectedEndpointsReachable *bool `json:"connected_endpoints_reachable,omitempty"`
@@ -102,12 +96,6 @@ type WritablePowerOutlet struct {
 	// Read Only: true
 	// Format: date-time
 	LastUpdated *strfmt.DateTime `json:"last_updated,omitempty"`
-
-	//
-	// Return the appropriate serializer for the link termination model.
-	//
-	// Read Only: true
-	LinkPeers []*string `json:"link_peers"`
 
 	// Link peers type
 	// Read Only: true
@@ -713,10 +701,6 @@ func (m *WritablePowerOutlet) ContextValidate(ctx context.Context, formats strfm
 		res = append(res, err)
 	}
 
-	if err := m.contextValidateConnectedEndpoints(ctx, formats); err != nil {
-		res = append(res, err)
-	}
-
 	if err := m.contextValidateConnectedEndpointsReachable(ctx, formats); err != nil {
 		res = append(res, err)
 	}
@@ -738,10 +722,6 @@ func (m *WritablePowerOutlet) ContextValidate(ctx context.Context, formats strfm
 	}
 
 	if err := m.contextValidateLastUpdated(ctx, formats); err != nil {
-		res = append(res, err)
-	}
-
-	if err := m.contextValidateLinkPeers(ctx, formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -797,15 +777,6 @@ func (m *WritablePowerOutlet) contextValidateCableEnd(ctx context.Context, forma
 	return nil
 }
 
-func (m *WritablePowerOutlet) contextValidateConnectedEndpoints(ctx context.Context, formats strfmt.Registry) error {
-
-	if err := validate.ReadOnly(ctx, "connected_endpoints", "body", []*string(m.ConnectedEndpoints)); err != nil {
-		return err
-	}
-
-	return nil
-}
-
 func (m *WritablePowerOutlet) contextValidateConnectedEndpointsReachable(ctx context.Context, formats strfmt.Registry) error {
 
 	if err := validate.ReadOnly(ctx, "connected_endpoints_reachable", "body", m.ConnectedEndpointsReachable); err != nil {
@@ -854,15 +825,6 @@ func (m *WritablePowerOutlet) contextValidateID(ctx context.Context, formats str
 func (m *WritablePowerOutlet) contextValidateLastUpdated(ctx context.Context, formats strfmt.Registry) error {
 
 	if err := validate.ReadOnly(ctx, "last_updated", "body", m.LastUpdated); err != nil {
-		return err
-	}
-
-	return nil
-}
-
-func (m *WritablePowerOutlet) contextValidateLinkPeers(ctx context.Context, formats strfmt.Registry) error {
-
-	if err := validate.ReadOnly(ctx, "link_peers", "body", []*string(m.LinkPeers)); err != nil {
 		return err
 	}
 

--- a/netbox/models/writable_power_port.go
+++ b/netbox/models/writable_power_port.go
@@ -55,12 +55,6 @@ type WritablePowerPort struct {
 	// Min Length: 1
 	CableEnd string `json:"cable_end,omitempty"`
 
-	//
-	// Return the appropriate serializer for the type of connected object.
-	//
-	// Read Only: true
-	ConnectedEndpoints []*string `json:"connected_endpoints"`
-
 	// Connected endpoints reachable
 	// Read Only: true
 	ConnectedEndpointsReachable *bool `json:"connected_endpoints_reachable,omitempty"`
@@ -103,12 +97,6 @@ type WritablePowerPort struct {
 	// Read Only: true
 	// Format: date-time
 	LastUpdated *strfmt.DateTime `json:"last_updated,omitempty"`
-
-	//
-	// Return the appropriate serializer for the link termination model.
-	//
-	// Read Only: true
-	LinkPeers []*string `json:"link_peers"`
 
 	// Link peers type
 	// Read Only: true
@@ -730,10 +718,6 @@ func (m *WritablePowerPort) ContextValidate(ctx context.Context, formats strfmt.
 		res = append(res, err)
 	}
 
-	if err := m.contextValidateConnectedEndpoints(ctx, formats); err != nil {
-		res = append(res, err)
-	}
-
 	if err := m.contextValidateConnectedEndpointsReachable(ctx, formats); err != nil {
 		res = append(res, err)
 	}
@@ -755,10 +739,6 @@ func (m *WritablePowerPort) ContextValidate(ctx context.Context, formats strfmt.
 	}
 
 	if err := m.contextValidateLastUpdated(ctx, formats); err != nil {
-		res = append(res, err)
-	}
-
-	if err := m.contextValidateLinkPeers(ctx, formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -814,15 +794,6 @@ func (m *WritablePowerPort) contextValidateCableEnd(ctx context.Context, formats
 	return nil
 }
 
-func (m *WritablePowerPort) contextValidateConnectedEndpoints(ctx context.Context, formats strfmt.Registry) error {
-
-	if err := validate.ReadOnly(ctx, "connected_endpoints", "body", []*string(m.ConnectedEndpoints)); err != nil {
-		return err
-	}
-
-	return nil
-}
-
 func (m *WritablePowerPort) contextValidateConnectedEndpointsReachable(ctx context.Context, formats strfmt.Registry) error {
 
 	if err := validate.ReadOnly(ctx, "connected_endpoints_reachable", "body", m.ConnectedEndpointsReachable); err != nil {
@@ -871,15 +842,6 @@ func (m *WritablePowerPort) contextValidateID(ctx context.Context, formats strfm
 func (m *WritablePowerPort) contextValidateLastUpdated(ctx context.Context, formats strfmt.Registry) error {
 
 	if err := validate.ReadOnly(ctx, "last_updated", "body", m.LastUpdated); err != nil {
-		return err
-	}
-
-	return nil
-}
-
-func (m *WritablePowerPort) contextValidateLinkPeers(ctx context.Context, formats strfmt.Registry) error {
-
-	if err := validate.ReadOnly(ctx, "link_peers", "body", []*string(m.LinkPeers)); err != nil {
 		return err
 	}
 

--- a/netbox/models/writable_rear_port.go
+++ b/netbox/models/writable_rear_port.go
@@ -88,12 +88,6 @@ type WritableRearPort struct {
 	// Format: date-time
 	LastUpdated *strfmt.DateTime `json:"last_updated,omitempty"`
 
-	//
-	// Return the appropriate serializer for the link termination model.
-	//
-	// Read Only: true
-	LinkPeers []*string `json:"link_peers"`
-
 	// Link peers type
 	// Read Only: true
 	LinkPeersType string `json:"link_peers_type,omitempty"`
@@ -566,10 +560,6 @@ func (m *WritableRearPort) ContextValidate(ctx context.Context, formats strfmt.R
 		res = append(res, err)
 	}
 
-	if err := m.contextValidateLinkPeers(ctx, formats); err != nil {
-		res = append(res, err)
-	}
-
 	if err := m.contextValidateLinkPeersType(ctx, formats); err != nil {
 		res = append(res, err)
 	}
@@ -652,15 +642,6 @@ func (m *WritableRearPort) contextValidateID(ctx context.Context, formats strfmt
 func (m *WritableRearPort) contextValidateLastUpdated(ctx context.Context, formats strfmt.Registry) error {
 
 	if err := validate.ReadOnly(ctx, "last_updated", "body", m.LastUpdated); err != nil {
-		return err
-	}
-
-	return nil
-}
-
-func (m *WritableRearPort) contextValidateLinkPeers(ctx context.Context, formats strfmt.Registry) error {
-
-	if err := validate.ReadOnly(ctx, "link_peers", "body", []*string(m.LinkPeers)); err != nil {
 		return err
 	}
 

--- a/preprocess.py
+++ b/preprocess.py
@@ -188,6 +188,16 @@ for definition, definition_spec in data["definitions"].items():
             del prop_spec["minimum"]
             logging.info(f"deleted minimum of {definition}.{prop}")
 
+# Delete fields that need custom serializer handling
+for definition, definition_spec in data["definitions"].items():
+    for prop, prop_spec in list(definition_spec["properties"].items()):
+        if (
+            "description" in prop_spec.keys()
+            and "appropriate serializer" in prop_spec["description"]
+        ):
+            del definition_spec["properties"][prop]
+            logging.info(f"deleted field {prop} with custom serializer")
+
 # Add custom fields to PrefixLength (https://github.com/fbreckle/go-netbox/pull/11)
 data["definitions"]["PrefixLength"]["properties"]["custom_fields"] = {
     "title": "Custom fields",

--- a/swagger.processed.json
+++ b/swagger.processed.json
@@ -72839,15 +72839,6 @@
           "readOnly": true,
           "minLength": 1
         },
-        "link_peers": {
-          "description": "\nReturn the appropriate serializer for the link termination model.\n",
-          "type": "array",
-          "items": {
-            "type": "string",
-            "x-nullable": true
-          },
-          "readOnly": true
-        },
         "link_peers_type": {
           "title": "Link peers type",
           "type": "string",
@@ -72973,15 +72964,6 @@
           "type": "string",
           "readOnly": true,
           "minLength": 1
-        },
-        "link_peers": {
-          "description": "\nReturn the appropriate serializer for the link termination model.\n",
-          "type": "array",
-          "items": {
-            "type": "string",
-            "x-nullable": true
-          },
-          "readOnly": true
         },
         "link_peers_type": {
           "title": "Link peers type",
@@ -75368,27 +75350,9 @@
           "readOnly": true,
           "minLength": 1
         },
-        "link_peers": {
-          "description": "\nReturn the appropriate serializer for the link termination model.\n",
-          "type": "array",
-          "items": {
-            "type": "string",
-            "x-nullable": true
-          },
-          "readOnly": true
-        },
         "link_peers_type": {
           "title": "Link peers type",
           "type": "string",
-          "readOnly": true
-        },
-        "connected_endpoints": {
-          "description": "\nReturn the appropriate serializer for the type of connected object.\n",
-          "type": "array",
-          "items": {
-            "type": "string",
-            "x-nullable": true
-          },
           "readOnly": true
         },
         "connected_endpoints_type": {
@@ -75534,27 +75498,9 @@
           "readOnly": true,
           "minLength": 1
         },
-        "link_peers": {
-          "description": "\nReturn the appropriate serializer for the link termination model.\n",
-          "type": "array",
-          "items": {
-            "type": "string",
-            "x-nullable": true
-          },
-          "readOnly": true
-        },
         "link_peers_type": {
           "title": "Link peers type",
           "type": "string",
-          "readOnly": true
-        },
-        "connected_endpoints": {
-          "description": "\nReturn the appropriate serializer for the type of connected object.\n",
-          "type": "array",
-          "items": {
-            "type": "string",
-            "x-nullable": true
-          },
           "readOnly": true
         },
         "connected_endpoints_type": {
@@ -75945,27 +75891,9 @@
           "readOnly": true,
           "minLength": 1
         },
-        "link_peers": {
-          "description": "\nReturn the appropriate serializer for the link termination model.\n",
-          "type": "array",
-          "items": {
-            "type": "string",
-            "x-nullable": true
-          },
-          "readOnly": true
-        },
         "link_peers_type": {
           "title": "Link peers type",
           "type": "string",
-          "readOnly": true
-        },
-        "connected_endpoints": {
-          "description": "\nReturn the appropriate serializer for the type of connected object.\n",
-          "type": "array",
-          "items": {
-            "type": "string",
-            "x-nullable": true
-          },
           "readOnly": true
         },
         "connected_endpoints_type": {
@@ -76111,27 +76039,9 @@
           "readOnly": true,
           "minLength": 1
         },
-        "link_peers": {
-          "description": "\nReturn the appropriate serializer for the link termination model.\n",
-          "type": "array",
-          "items": {
-            "type": "string",
-            "x-nullable": true
-          },
-          "readOnly": true
-        },
         "link_peers_type": {
           "title": "Link peers type",
           "type": "string",
-          "readOnly": true
-        },
-        "connected_endpoints": {
-          "description": "\nReturn the appropriate serializer for the type of connected object.\n",
-          "type": "array",
-          "items": {
-            "type": "string",
-            "x-nullable": true
-          },
           "readOnly": true
         },
         "connected_endpoints_type": {
@@ -77920,15 +77830,6 @@
           "readOnly": true,
           "minLength": 1
         },
-        "link_peers": {
-          "description": "\nReturn the appropriate serializer for the link termination model.\n",
-          "type": "array",
-          "items": {
-            "type": "string",
-            "x-nullable": true
-          },
-          "readOnly": true
-        },
         "link_peers_type": {
           "title": "Link peers type",
           "type": "string",
@@ -78095,15 +77996,6 @@
           "type": "string",
           "readOnly": true,
           "minLength": 1
-        },
-        "link_peers": {
-          "description": "\nReturn the appropriate serializer for the link termination model.\n",
-          "type": "array",
-          "items": {
-            "type": "string",
-            "x-nullable": true
-          },
-          "readOnly": true
         },
         "link_peers_type": {
           "title": "Link peers type",
@@ -79944,15 +79836,6 @@
         "wireless_link": {
           "$ref": "#/definitions/NestedWirelessLink"
         },
-        "link_peers": {
-          "description": "\nReturn the appropriate serializer for the link termination model.\n",
-          "type": "array",
-          "items": {
-            "type": "string",
-            "x-nullable": true
-          },
-          "readOnly": true
-        },
         "link_peers_type": {
           "title": "Link peers type",
           "type": "string",
@@ -79970,15 +79853,6 @@
         },
         "l2vpn_termination": {
           "$ref": "#/definitions/NestedL2VPNTermination"
-        },
-        "connected_endpoints": {
-          "description": "\nReturn the appropriate serializer for the type of connected object.\n",
-          "type": "array",
-          "items": {
-            "type": "string",
-            "x-nullable": true
-          },
-          "readOnly": true
         },
         "connected_endpoints_type": {
           "title": "Connected endpoints type",
@@ -80554,15 +80428,6 @@
           "type": "integer",
           "x-nullable": true
         },
-        "link_peers": {
-          "description": "\nReturn the appropriate serializer for the link termination model.\n",
-          "type": "array",
-          "items": {
-            "type": "string",
-            "x-nullable": true
-          },
-          "readOnly": true
-        },
         "link_peers_type": {
           "title": "Link peers type",
           "type": "string",
@@ -80584,15 +80449,6 @@
         "l2vpn_termination": {
           "title": "L2vpn termination",
           "type": "string",
-          "readOnly": true
-        },
-        "connected_endpoints": {
-          "description": "\nReturn the appropriate serializer for the type of connected object.\n",
-          "type": "array",
-          "items": {
-            "type": "string",
-            "x-nullable": true
-          },
           "readOnly": true
         },
         "connected_endpoints_type": {
@@ -82749,27 +82605,9 @@
           "readOnly": true,
           "minLength": 1
         },
-        "link_peers": {
-          "description": "\nReturn the appropriate serializer for the link termination model.\n",
-          "type": "array",
-          "items": {
-            "type": "string",
-            "x-nullable": true
-          },
-          "readOnly": true
-        },
         "link_peers_type": {
           "title": "Link peers type",
           "type": "string",
-          "readOnly": true
-        },
-        "connected_endpoints": {
-          "description": "\nReturn the appropriate serializer for the type of connected object.\n",
-          "type": "array",
-          "items": {
-            "type": "string",
-            "x-nullable": true
-          },
           "readOnly": true
         },
         "connected_endpoints_type": {
@@ -82928,27 +82766,9 @@
           "readOnly": true,
           "minLength": 1
         },
-        "link_peers": {
-          "description": "\nReturn the appropriate serializer for the link termination model.\n",
-          "type": "array",
-          "items": {
-            "type": "string",
-            "x-nullable": true
-          },
-          "readOnly": true
-        },
         "link_peers_type": {
           "title": "Link peers type",
           "type": "string",
-          "readOnly": true
-        },
-        "connected_endpoints": {
-          "description": "\nReturn the appropriate serializer for the type of connected object.\n",
-          "type": "array",
-          "items": {
-            "type": "string",
-            "x-nullable": true
-          },
           "readOnly": true
         },
         "connected_endpoints_type": {
@@ -83835,27 +83655,9 @@
           "readOnly": true,
           "minLength": 1
         },
-        "link_peers": {
-          "description": "\nReturn the appropriate serializer for the link termination model.\n",
-          "type": "array",
-          "items": {
-            "type": "string",
-            "x-nullable": true
-          },
-          "readOnly": true
-        },
         "link_peers_type": {
           "title": "Link peers type",
           "type": "string",
-          "readOnly": true
-        },
-        "connected_endpoints": {
-          "description": "\nReturn the appropriate serializer for the type of connected object.\n",
-          "type": "array",
-          "items": {
-            "type": "string",
-            "x-nullable": true
-          },
           "readOnly": true
         },
         "connected_endpoints_type": {
@@ -84075,27 +83877,9 @@
           "readOnly": true,
           "minLength": 1
         },
-        "link_peers": {
-          "description": "\nReturn the appropriate serializer for the link termination model.\n",
-          "type": "array",
-          "items": {
-            "type": "string",
-            "x-nullable": true
-          },
-          "readOnly": true
-        },
         "link_peers_type": {
           "title": "Link peers type",
           "type": "string",
-          "readOnly": true
-        },
-        "connected_endpoints": {
-          "description": "\nReturn the appropriate serializer for the type of connected object.\n",
-          "type": "array",
-          "items": {
-            "type": "string",
-            "x-nullable": true
-          },
           "readOnly": true
         },
         "connected_endpoints_type": {
@@ -85062,27 +84846,9 @@
           "readOnly": true,
           "minLength": 1
         },
-        "link_peers": {
-          "description": "\nReturn the appropriate serializer for the link termination model.\n",
-          "type": "array",
-          "items": {
-            "type": "string",
-            "x-nullable": true
-          },
-          "readOnly": true
-        },
         "link_peers_type": {
           "title": "Link peers type",
           "type": "string",
-          "readOnly": true
-        },
-        "connected_endpoints": {
-          "description": "\nReturn the appropriate serializer for the type of connected object.\n",
-          "type": "array",
-          "items": {
-            "type": "string",
-            "x-nullable": true
-          },
           "readOnly": true
         },
         "connected_endpoints_type": {
@@ -85310,27 +85076,9 @@
           "readOnly": true,
           "minLength": 1
         },
-        "link_peers": {
-          "description": "\nReturn the appropriate serializer for the link termination model.\n",
-          "type": "array",
-          "items": {
-            "type": "string",
-            "x-nullable": true
-          },
-          "readOnly": true
-        },
         "link_peers_type": {
           "title": "Link peers type",
           "type": "string",
-          "readOnly": true
-        },
-        "connected_endpoints": {
-          "description": "\nReturn the appropriate serializer for the type of connected object.\n",
-          "type": "array",
-          "items": {
-            "type": "string",
-            "x-nullable": true
-          },
           "readOnly": true
         },
         "connected_endpoints_type": {
@@ -86770,15 +86518,6 @@
           "readOnly": true,
           "minLength": 1
         },
-        "link_peers": {
-          "description": "\nReturn the appropriate serializer for the link termination model.\n",
-          "type": "array",
-          "items": {
-            "type": "string",
-            "x-nullable": true
-          },
-          "readOnly": true
-        },
         "link_peers_type": {
           "title": "Link peers type",
           "type": "string",
@@ -86940,15 +86679,6 @@
           "type": "string",
           "readOnly": true,
           "minLength": 1
-        },
-        "link_peers": {
-          "description": "\nReturn the appropriate serializer for the link termination model.\n",
-          "type": "array",
-          "items": {
-            "type": "string",
-            "x-nullable": true
-          },
-          "readOnly": true
         },
         "link_peers_type": {
           "title": "Link peers type",


### PR DESCRIPTION
`link_peers` is actually an array of objects and is not implemented properly in the `swagger.json` definition.

As soon as a circuit termination is connected to a device interface the Terraform provider cannot unmarshal the response anymore:

```
│ Error: json: cannot unmarshal object into Go struct field CircuitTermination.link_peers of type string
│ 
│   with netbox_circuit_termination.megaport-leaseweb["WDC-02"],
│   on megaport.tf line 92, in resource "netbox_circuit_termination" "megaport-leaseweb":
│   92: resource "netbox_circuit_termination" "megaport-leaseweb" {
```

However, this attribute is not used in the provider anyway, so I have removed it instead of trying to fix it.