### PR TITLE
:bug: Fix Prefix Bulk Update

### DIFF
--- a/netbox/client/ipam/ipam_prefixes_bulk_update_parameters.go
+++ b/netbox/client/ipam/ipam_prefixes_bulk_update_parameters.go
@@ -79,7 +79,7 @@ IpamPrefixesBulkUpdateParams contains all the parameters to send to the API endp
 type IpamPrefixesBulkUpdateParams struct {
 
 	// Data.
-	Data *models.WritablePrefix
+	Data []*models.WritablePrefix
 
 	timeout    time.Duration
 	Context    context.Context
@@ -135,13 +135,13 @@ func (o *IpamPrefixesBulkUpdateParams) SetHTTPClient(client *http.Client) {
 }
 
 // WithData adds the data to the ipam prefixes bulk update params
-func (o *IpamPrefixesBulkUpdateParams) WithData(data *models.WritablePrefix) *IpamPrefixesBulkUpdateParams {
+func (o *IpamPrefixesBulkUpdateParams) WithData(data []*models.WritablePrefix) *IpamPrefixesBulkUpdateParams {
 	o.SetData(data)
 	return o
 }
 
 // SetData adds the data to the ipam prefixes bulk update params
-func (o *IpamPrefixesBulkUpdateParams) SetData(data *models.WritablePrefix) {
+func (o *IpamPrefixesBulkUpdateParams) SetData(data []*models.WritablePrefix) {
 	o.Data = data
 }
 

--- a/netbox/client/ipam/ipam_prefixes_bulk_update_responses.go
+++ b/netbox/client/ipam/ipam_prefixes_bulk_update_responses.go
@@ -67,7 +67,7 @@ IpamPrefixesBulkUpdateOK describes a response with status code 200, with default
 IpamPrefixesBulkUpdateOK ipam prefixes bulk update o k
 */
 type IpamPrefixesBulkUpdateOK struct {
-	Payload *models.Prefix
+	Payload []*models.Prefix
 }
 
 // IsSuccess returns true when this ipam prefixes bulk update o k response has a 2xx status code
@@ -103,16 +103,14 @@ func (o *IpamPrefixesBulkUpdateOK) String() string {
 	return fmt.Sprintf("[PUT /ipam/prefixes/][%d] ipamPrefixesBulkUpdateOK  %+v", 200, o.Payload)
 }
 
-func (o *IpamPrefixesBulkUpdateOK) GetPayload() *models.Prefix {
+func (o *IpamPrefixesBulkUpdateOK) GetPayload() []*models.Prefix {
 	return o.Payload
 }
 
 func (o *IpamPrefixesBulkUpdateOK) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
 
-	o.Payload = new(models.Prefix)
-
 	// response payload
-	if err := consumer.Consume(response.Body(), o.Payload); err != nil && err != io.EOF {
+	if err := consumer.Consume(response.Body(), &o.Payload); err != nil && err != io.EOF {
 		return err
 	}
 

--- a/preprocess.py
+++ b/preprocess.py
@@ -236,6 +236,24 @@ data["paths"]["/ipam/prefixes/{id}/available-prefixes/"]["post"]["responses"]["2
     "schema": {"$ref": "#/definitions/Prefix"},
 }
 
+# Use array of WritablePrefix in prefix bulk update endpoint
+logging.info("Use array in prefix bulk update endpoint")
+data["paths"]["/ipam/prefixes/"]["put"]["parameters"] = [
+    {
+        "name": "data",
+        "in": "body",
+        "required": True,
+        "schema": {"type": "array", "items": {"$ref": "#/definitions/WritablePrefix"}},
+    }
+]
+
+# Use array of Prefix in prefix bulk update endpoint response
+logging.info("Use array in prefix bulk update endpoint")
+data["paths"]["/ipam/prefixes/"]["put"]["responses"]["200"] = {
+    "description": "",
+    "schema": {"type": "array", "items": {"$ref": "#/definitions/Prefix"}},
+}
+
 # Write output file
 with open("swagger.processed.json", "w") as writefile:
     json.dump(data, writefile, indent=2)

--- a/swagger.processed.json
+++ b/swagger.processed.json
@@ -52817,7 +52817,10 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/WritablePrefix"
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/WritablePrefix"
+              }
             }
           }
         ],
@@ -52825,7 +52828,10 @@
           "200": {
             "description": "",
             "schema": {
-              "$ref": "#/definitions/Prefix"
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/Prefix"
+              }
             }
           },
           "default": {


### PR DESCRIPTION
## Background
Currently, `IpamPrefixesBulkUpdate()` endpoint accepts single `WritablePrefix` object as input data. When this is used to update a prefix, Netbox returns the following error:

```
[PUT /ipam/prefixes/][400] ipam_prefixes_bulk_update default  map[non_field_errors:[Expected a list of items but got type "dict".]]
```

Also, because it only accepts single `WritablePrefix` object, there is no way to bulk update using this endpoint.

## Fix
Replace `IpamPrefixesBulkUpdate()`'s input parameter to accept array of `WritablePrefix`. Also update its `200` response to return array of Prefixes.