### PR TITLE
fix: allow permissions constraint to be nullable

### DIFF
--- a/netbox/models/writable_object_permission.go
+++ b/netbox/models/writable_object_permission.go
@@ -42,7 +42,7 @@ type WritableObjectPermission struct {
 	// Constraints
 	//
 	// Queryset filter matching the applicable objects of the selected type(s)
-	Constraints interface{} `json:"constraints,omitempty"`
+	Constraints interface{} `json:"constraints"`
 
 	// Description
 	// Max Length: 200

--- a/preprocess.py
+++ b/preprocess.py
@@ -106,8 +106,10 @@ for prop, prop_spec in data["definitions"]["WritableRack"]["properties"].items()
         logging.info(f"set x-omitempty = false on WritableRack.{prop}")
 
 data["definitions"]["WritableCustomField"]["properties"]["required"][
-    "x-omitempty"
-] = False
+    "x-omitempty"] = False
+
+data["definitions"]["WritableObjectPermission"]["properties"]["constraints"][
+    "x-omitempty"] = False
 
 # This implements https://github.com/fbreckle/go-netbox/commit/1363e14cfc7bce4bd3d5ee93c09ca70543c51279
 for prop, prop_spec in data["definitions"]["WritableVirtualMachineWithConfigContext"][

--- a/swagger.processed.json
+++ b/swagger.processed.json
@@ -94818,7 +94818,8 @@
           "title": "Constraints",
           "description": "Queryset filter matching the applicable objects of the selected type(s)",
           "type": "object",
-          "x-nullable": true
+          "x-nullable": true,
+          "x-omitempty": false
         }
       }
     },


### PR DESCRIPTION
With the current configuration, if we pass a null value to clear the constraint field and make it null, the field is ommitted and thus no changes are made.

With this change, we update the field to remove omitempty, which allows us to send a null value to the field, thus clearing it when it's empty.

Critical part of the fix here:
https://github.com/e-breuninger/terraform-provider-netbox/pull/432