### PR TITLE
Fix available vlan response

### DIFF
--- a/netbox/client/ipam/ipam_vlan_groups_available_vlans_create_responses.go
+++ b/netbox/client/ipam/ipam_vlan_groups_available_vlans_create_responses.go
@@ -68,7 +68,7 @@ IpamVlanGroupsAvailableVlansCreateCreated describes a response with status code 
 IpamVlanGroupsAvailableVlansCreateCreated ipam vlan groups available vlans create created
 */
 type IpamVlanGroupsAvailableVlansCreateCreated struct {
-	Payload []*models.VLAN
+	Payload *models.VLAN
 }
 
 // IsSuccess returns true when this ipam vlan groups available vlans create created response has a 2xx status code
@@ -111,7 +111,7 @@ func (o *IpamVlanGroupsAvailableVlansCreateCreated) String() string {
 	return fmt.Sprintf("[POST /ipam/vlan-groups/{id}/available-vlans/][%d] ipamVlanGroupsAvailableVlansCreateCreated %s", 201, payload)
 }
 
-func (o *IpamVlanGroupsAvailableVlansCreateCreated) GetPayload() []*models.VLAN {
+func (o *IpamVlanGroupsAvailableVlansCreateCreated) GetPayload() *models.VLAN {
 	return o.Payload
 }
 

--- a/netbox/models/group.go
+++ b/netbox/models/group.go
@@ -34,6 +34,10 @@ import (
 // swagger:model Group
 type Group struct {
 
+	// Description
+	// Max Length: 200
+	Description string `json:"description,omitempty"`
+
 	// Display
 	// Read Only: true
 	Display string `json:"display,omitempty"`
@@ -62,6 +66,10 @@ type Group struct {
 func (m *Group) Validate(formats strfmt.Registry) error {
 	var res []error
 
+	if err := m.validateDescription(formats); err != nil {
+		res = append(res, err)
+	}
+
 	if err := m.validateName(formats); err != nil {
 		res = append(res, err)
 	}
@@ -73,6 +81,18 @@ func (m *Group) Validate(formats strfmt.Registry) error {
 	if len(res) > 0 {
 		return errors.CompositeValidationError(res...)
 	}
+	return nil
+}
+
+func (m *Group) validateDescription(formats strfmt.Registry) error {
+	if swag.IsZero(m.Description) { // not required
+		return nil
+	}
+
+	if err := validate.MaxLength("description", "body", m.Description, 200); err != nil {
+		return err
+	}
+
 	return nil
 }
 

--- a/swagger.json
+++ b/swagger.json
@@ -91653,6 +91653,11 @@
           "maxLength": 150,
           "minLength": 1
         },
+        "description": {
+          "title": "Description",
+          "type": "string",
+          "maxLength": 200
+        },
         "user_count": {
           "title": "User count",
           "type": "integer",

--- a/swagger.processed.json
+++ b/swagger.processed.json
@@ -90877,6 +90877,11 @@
           "maxLength": 150,
           "minLength": 1
         },
+        "description": {
+          "title": "Description",
+          "type": "string",
+          "maxLength": 200
+        },
         "user_count": {
           "title": "User count",
           "type": "integer",


### PR DESCRIPTION
Based on issue #48, the create response from the Netbox API is actually only returning one VLAN and not a slice.
Updated the library code for the return type.