### PR TITLE
 feat: relax Token.Key max length to support v2 token format

### DIFF
--- a/netbox/models/token.go
+++ b/netbox/models/token.go
@@ -59,8 +59,8 @@ type Token struct {
 	ID int64 `json:"id,omitempty"`
 
 	// Key
-	// Max Length: 40
-	// Min Length: 40
+	// Max Length: 12
+	// Min Length: 12
 	Key string `json:"key,omitempty"`
 
 	// Last used
@@ -161,11 +161,11 @@ func (m *Token) validateKey(formats strfmt.Registry) error {
 		return nil
 	}
 
-	if err := validate.MinLength("key", "body", m.Key, 40); err != nil {
+	if err := validate.MinLength("key", "body", m.Key, 12); err != nil {
 		return err
 	}
 
-	if err := validate.MaxLength("key", "body", m.Key, 40); err != nil {
+	if err := validate.MaxLength("key", "body", m.Key, 12); err != nil {
 		return err
 	}
 

--- a/netbox/models/writable_token.go
+++ b/netbox/models/writable_token.go
@@ -59,8 +59,8 @@ type WritableToken struct {
 	ID int64 `json:"id,omitempty"`
 
 	// Key
-	// Max Length: 40
-	// Min Length: 40
+	// Max Length: 12
+	// Min Length: 12
 	Key string `json:"key,omitempty"`
 
 	// Last used
@@ -161,11 +161,11 @@ func (m *WritableToken) validateKey(formats strfmt.Registry) error {
 		return nil
 	}
 
-	if err := validate.MinLength("key", "body", m.Key, 40); err != nil {
+	if err := validate.MinLength("key", "body", m.Key, 12); err != nil {
 		return err
 	}
 
-	if err := validate.MaxLength("key", "body", m.Key, 40); err != nil {
+	if err := validate.MaxLength("key", "body", m.Key, 12); err != nil {
 		return err
 	}
 

--- a/swagger.json
+++ b/swagger.json
@@ -91925,8 +91925,8 @@
         "key": {
           "title": "Key",
           "type": "string",
-          "maxLength": 40,
-          "minLength": 40
+          "maxLength": 12,
+          "minLength": 12
         },
         "write_enabled": {
           "title": "Write enabled",
@@ -91994,8 +91994,8 @@
         "key": {
           "title": "Key",
           "type": "string",
-          "maxLength": 40,
-          "minLength": 40
+          "maxLength": 12,
+          "minLength": 12
         },
         "write_enabled": {
           "title": "Write enabled",

--- a/swagger.processed.json
+++ b/swagger.processed.json
@@ -91534,8 +91534,8 @@
         "key": {
           "title": "Key",
           "type": "string",
-          "maxLength": 40,
-          "minLength": 40
+          "maxLength": 12,
+          "minLength": 12
         },
         "write_enabled": {
           "title": "Write enabled",
@@ -91603,8 +91603,8 @@
         "key": {
           "title": "Key",
           "type": "string",
-          "maxLength": 40,
-          "minLength": 40
+          "maxLength": 12,
+          "minLength": 12
         },
         "write_enabled": {
           "title": "Write enabled",


### PR DESCRIPTION
## Summary

NetBox v2 tokens use a 12-char identification key (`TOKEN_KEY_LENGTH=12` in `users/constants.py`), separate from the 40-char token plaintext. The previous hard limit of 40 on `Token.Key` and `WritableToken.Key` was designed for v1 only and rejects valid v2 keys.

V1 tokens have `key=null`, so the `IsZero` guard in validation skips the length check for them — no v1 compatibility is broken.

## Token format reference (from NetBox source)
| Constant | Value |
|---|---|
| `TOKEN_PREFIX` | `nbt_` (4 chars) |
| `TOKEN_KEY_LENGTH` | 12 chars |
| `TOKEN_DEFAULT_LENGTH` | 40 chars |

Full bearer token: `nbt_<12-char-key>.<40-char-token>` = 57 chars total