### PR TITLE
fix: remove omitempty from WritableToken.Expires to allow clearing expiry

### DIFF
--- a/netbox/models/writable_token.go
+++ b/netbox/models/writable_token.go
@@ -52,7 +52,7 @@ type WritableToken struct {
 
 	// Expires
 	// Format: date-time
-	Expires *strfmt.DateTime `json:"expires,omitempty"`
+	Expires *strfmt.DateTime `json:"expires"`
 
 	// ID
 	// Read Only: true

--- a/swagger.processed.json
+++ b/swagger.processed.json
@@ -91592,7 +91592,8 @@
           "title": "Expires",
           "type": "string",
           "format": "date-time",
-          "x-nullable": true
+          "x-nullable": true,
+          "x-omitempty": false
         },
         "last_used": {
           "title": "Last used",


### PR DESCRIPTION
## Summary 
The `Expires` field on `WritableToken` is tagged with `omitempty`, which causes a nil pointer to be omitted entirely from the JSON body in PUT requests. This makes it impossible to clear an existing expiry date — NetBox never receives the field and keeps the old value. To fix this, remove `omitempty` from the `Expires` field so that a nil pointer serializes as `"expires": null`, explicitly instructing NetBox to clear the expiration.

## Related
Fixes the deeper issue behind e-breuninger/terraform-provider-netbox#772, where token expiry cannot be unset once assigned.