### PR TITLE
fix: custom field validation min max

### DIFF
--- a/netbox/models/custom_field.go
+++ b/netbox/models/custom_field.go
@@ -137,14 +137,14 @@ type CustomField struct {
 	// Maximum allowed value (for numeric fields)
 	// Maximum: 2.147483647e+09
 	// Minimum: -2.147483648e+09
-	ValidationMaximum *int64 `json:"validation_maximum,omitempty"`
+	ValidationMaximum *float64 `json:"validation_maximum,omitempty"`
 
 	// Minimum value
 	//
 	// Minimum allowed value (for numeric fields)
 	// Maximum: 2.147483647e+09
 	// Minimum: -2.147483648e+09
-	ValidationMinimum *int64 `json:"validation_minimum,omitempty"`
+	ValidationMinimum *float64 `json:"validation_minimum,omitempty"`
 
 	// Validation regex
 	//
@@ -773,11 +773,11 @@ func (m *CustomField) validateValidationMaximum(formats strfmt.Registry) error {
 		return nil
 	}
 
-	if err := validate.MinimumInt("validation_maximum", "body", *m.ValidationMaximum, -2.147483648e+09, false); err != nil {
+	if err := validate.Minimum("validation_maximum", "body", *m.ValidationMaximum, -2.147483648e+09, false); err != nil {
 		return err
 	}
 
-	if err := validate.MaximumInt("validation_maximum", "body", *m.ValidationMaximum, 2.147483647e+09, false); err != nil {
+	if err := validate.Maximum("validation_maximum", "body", *m.ValidationMaximum, 2.147483647e+09, false); err != nil {
 		return err
 	}
 
@@ -789,11 +789,11 @@ func (m *CustomField) validateValidationMinimum(formats strfmt.Registry) error {
 		return nil
 	}
 
-	if err := validate.MinimumInt("validation_minimum", "body", *m.ValidationMinimum, -2.147483648e+09, false); err != nil {
+	if err := validate.Minimum("validation_minimum", "body", *m.ValidationMinimum, -2.147483648e+09, false); err != nil {
 		return err
 	}
 
-	if err := validate.MaximumInt("validation_minimum", "body", *m.ValidationMinimum, 2.147483647e+09, false); err != nil {
+	if err := validate.Maximum("validation_minimum", "body", *m.ValidationMinimum, 2.147483647e+09, false); err != nil {
 		return err
 	}
 

--- a/netbox/models/writable_custom_field.go
+++ b/netbox/models/writable_custom_field.go
@@ -145,14 +145,14 @@ type WritableCustomField struct {
 	// Maximum allowed value (for numeric fields)
 	// Maximum: 2.147483647e+09
 	// Minimum: -2.147483648e+09
-	ValidationMaximum *int64 `json:"validation_maximum,omitempty"`
+	ValidationMaximum *float64 `json:"validation_maximum,omitempty"`
 
 	// Minimum value
 	//
 	// Minimum allowed value (for numeric fields)
 	// Maximum: 2.147483647e+09
 	// Minimum: -2.147483648e+09
-	ValidationMinimum *int64 `json:"validation_minimum,omitempty"`
+	ValidationMinimum *float64 `json:"validation_minimum,omitempty"`
 
 	// Validation regex
 	//
@@ -862,11 +862,11 @@ func (m *WritableCustomField) validateValidationMaximum(formats strfmt.Registry)
 		return nil
 	}
 
-	if err := validate.MinimumInt("validation_maximum", "body", *m.ValidationMaximum, -2.147483648e+09, false); err != nil {
+	if err := validate.Minimum("validation_maximum", "body", *m.ValidationMaximum, -2.147483648e+09, false); err != nil {
 		return err
 	}
 
-	if err := validate.MaximumInt("validation_maximum", "body", *m.ValidationMaximum, 2.147483647e+09, false); err != nil {
+	if err := validate.Maximum("validation_maximum", "body", *m.ValidationMaximum, 2.147483647e+09, false); err != nil {
 		return err
 	}
 
@@ -878,11 +878,11 @@ func (m *WritableCustomField) validateValidationMinimum(formats strfmt.Registry)
 		return nil
 	}
 
-	if err := validate.MinimumInt("validation_minimum", "body", *m.ValidationMinimum, -2.147483648e+09, false); err != nil {
+	if err := validate.Minimum("validation_minimum", "body", *m.ValidationMinimum, -2.147483648e+09, false); err != nil {
 		return err
 	}
 
-	if err := validate.MaximumInt("validation_minimum", "body", *m.ValidationMinimum, 2.147483647e+09, false); err != nil {
+	if err := validate.Maximum("validation_minimum", "body", *m.ValidationMinimum, 2.147483647e+09, false); err != nil {
 		return err
 	}
 

--- a/swagger.json
+++ b/swagger.json
@@ -85900,7 +85900,7 @@
         "validation_minimum": {
           "title": "Minimum value",
           "description": "Minimum allowed value (for numeric fields)",
-          "type": "integer",
+          "type": "number",
           "maximum": 2147483647,
           "minimum": -2147483648,
           "x-nullable": true
@@ -85908,7 +85908,7 @@
         "validation_maximum": {
           "title": "Maximum value",
           "description": "Maximum allowed value (for numeric fields)",
-          "type": "integer",
+          "type": "number",
           "maximum": 2147483647,
           "minimum": -2147483648,
           "x-nullable": true
@@ -86085,7 +86085,7 @@
         "validation_minimum": {
           "title": "Minimum value",
           "description": "Minimum allowed value (for numeric fields)",
-          "type": "integer",
+          "type": "number",
           "maximum": 2147483647,
           "minimum": -2147483648,
           "x-nullable": true
@@ -86093,7 +86093,7 @@
         "validation_maximum": {
           "title": "Maximum value",
           "description": "Maximum allowed value (for numeric fields)",
-          "type": "integer",
+          "type": "number",
           "maximum": 2147483647,
           "minimum": -2147483648,
           "x-nullable": true

--- a/swagger.processed.json
+++ b/swagger.processed.json
@@ -85576,7 +85576,7 @@
         "validation_minimum": {
           "title": "Minimum value",
           "description": "Minimum allowed value (for numeric fields)",
-          "type": "integer",
+          "type": "number",
           "maximum": 2147483647,
           "minimum": -2147483648,
           "x-nullable": true
@@ -85584,7 +85584,7 @@
         "validation_maximum": {
           "title": "Maximum value",
           "description": "Maximum allowed value (for numeric fields)",
-          "type": "integer",
+          "type": "number",
           "maximum": 2147483647,
           "minimum": -2147483648,
           "x-nullable": true
@@ -85852,7 +85852,7 @@
         "validation_minimum": {
           "title": "Minimum value",
           "description": "Minimum allowed value (for numeric fields)",
-          "type": "integer",
+          "type": "number",
           "maximum": 2147483647,
           "minimum": -2147483648,
           "x-nullable": true
@@ -85860,7 +85860,7 @@
         "validation_maximum": {
           "title": "Maximum value",
           "description": "Maximum allowed value (for numeric fields)",
-          "type": "integer",
+          "type": "number",
           "maximum": 2147483647,
           "minimum": -2147483648,
           "x-nullable": true


### PR DESCRIPTION
- change model from int to float

This change was introduced in 4.4.X

As specify in OpenAPI doc, integer are included in number, so old values are already supported https://swagger.io/docs/specification/v3_0/data-models/data-types/#numbers