### PR TITLE
fix: correct ui_visible JSON tag on WritableCustomField (was ui_visibility)

### DIFF
--- a/netbox/client/dcim/dcim_console_port_templates_list_parameters.go
+++ b/netbox/client/dcim/dcim_console_port_templates_list_parameters.go
@@ -806,7 +806,7 @@ func (o *DcimConsolePortTemplatesListParams) WriteToRequest(r runtime.ClientRequ
 		qDevicetypeID := qrDevicetypeID
 		if qDevicetypeID != "" {
 
-			if err := r.SetQueryParam("devicetype_id", qDevicetypeID); err != nil {
+			if err := r.SetQueryParam("device_type_id", qDevicetypeID); err != nil {
 				return err
 			}
 		}
@@ -823,7 +823,7 @@ func (o *DcimConsolePortTemplatesListParams) WriteToRequest(r runtime.ClientRequ
 		qDevicetypeIDn := qrDevicetypeIDn
 		if qDevicetypeIDn != "" {
 
-			if err := r.SetQueryParam("devicetype_id__n", qDevicetypeIDn); err != nil {
+			if err := r.SetQueryParam("device_type_id__n", qDevicetypeIDn); err != nil {
 				return err
 			}
 		}
@@ -1061,7 +1061,7 @@ func (o *DcimConsolePortTemplatesListParams) WriteToRequest(r runtime.ClientRequ
 		qModuletypeID := qrModuletypeID
 		if qModuletypeID != "" {
 
-			if err := r.SetQueryParam("moduletype_id", qModuletypeID); err != nil {
+			if err := r.SetQueryParam("module_type_id", qModuletypeID); err != nil {
 				return err
 			}
 		}
@@ -1078,7 +1078,7 @@ func (o *DcimConsolePortTemplatesListParams) WriteToRequest(r runtime.ClientRequ
 		qModuletypeIDn := qrModuletypeIDn
 		if qModuletypeIDn != "" {
 
-			if err := r.SetQueryParam("moduletype_id__n", qModuletypeIDn); err != nil {
+			if err := r.SetQueryParam("module_type_id__n", qModuletypeIDn); err != nil {
 				return err
 			}
 		}

--- a/netbox/client/dcim/dcim_console_server_port_templates_list_parameters.go
+++ b/netbox/client/dcim/dcim_console_server_port_templates_list_parameters.go
@@ -806,7 +806,7 @@ func (o *DcimConsoleServerPortTemplatesListParams) WriteToRequest(r runtime.Clie
 		qDevicetypeID := qrDevicetypeID
 		if qDevicetypeID != "" {
 
-			if err := r.SetQueryParam("devicetype_id", qDevicetypeID); err != nil {
+			if err := r.SetQueryParam("device_type_id", qDevicetypeID); err != nil {
 				return err
 			}
 		}
@@ -823,7 +823,7 @@ func (o *DcimConsoleServerPortTemplatesListParams) WriteToRequest(r runtime.Clie
 		qDevicetypeIDn := qrDevicetypeIDn
 		if qDevicetypeIDn != "" {
 
-			if err := r.SetQueryParam("devicetype_id__n", qDevicetypeIDn); err != nil {
+			if err := r.SetQueryParam("device_type_id__n", qDevicetypeIDn); err != nil {
 				return err
 			}
 		}
@@ -1061,7 +1061,7 @@ func (o *DcimConsoleServerPortTemplatesListParams) WriteToRequest(r runtime.Clie
 		qModuletypeID := qrModuletypeID
 		if qModuletypeID != "" {
 
-			if err := r.SetQueryParam("moduletype_id", qModuletypeID); err != nil {
+			if err := r.SetQueryParam("module_type_id", qModuletypeID); err != nil {
 				return err
 			}
 		}
@@ -1078,7 +1078,7 @@ func (o *DcimConsoleServerPortTemplatesListParams) WriteToRequest(r runtime.Clie
 		qModuletypeIDn := qrModuletypeIDn
 		if qModuletypeIDn != "" {
 
-			if err := r.SetQueryParam("moduletype_id__n", qModuletypeIDn); err != nil {
+			if err := r.SetQueryParam("module_type_id__n", qModuletypeIDn); err != nil {
 				return err
 			}
 		}

--- a/netbox/client/dcim/dcim_device_bay_templates_list_parameters.go
+++ b/netbox/client/dcim/dcim_device_bay_templates_list_parameters.go
@@ -750,7 +750,7 @@ func (o *DcimDeviceBayTemplatesListParams) WriteToRequest(r runtime.ClientReques
 		qDevicetypeID := qrDevicetypeID
 		if qDevicetypeID != "" {
 
-			if err := r.SetQueryParam("devicetype_id", qDevicetypeID); err != nil {
+			if err := r.SetQueryParam("device_type_id", qDevicetypeID); err != nil {
 				return err
 			}
 		}
@@ -767,7 +767,7 @@ func (o *DcimDeviceBayTemplatesListParams) WriteToRequest(r runtime.ClientReques
 		qDevicetypeIDn := qrDevicetypeIDn
 		if qDevicetypeIDn != "" {
 
-			if err := r.SetQueryParam("devicetype_id__n", qDevicetypeIDn); err != nil {
+			if err := r.SetQueryParam("device_type_id__n", qDevicetypeIDn); err != nil {
 				return err
 			}
 		}

--- a/netbox/client/dcim/dcim_front_port_templates_list_parameters.go
+++ b/netbox/client/dcim/dcim_front_port_templates_list_parameters.go
@@ -1147,7 +1147,7 @@ func (o *DcimFrontPortTemplatesListParams) WriteToRequest(r runtime.ClientReques
 		qDevicetypeID := qrDevicetypeID
 		if qDevicetypeID != "" {
 
-			if err := r.SetQueryParam("devicetype_id", qDevicetypeID); err != nil {
+			if err := r.SetQueryParam("device_type_id", qDevicetypeID); err != nil {
 				return err
 			}
 		}
@@ -1164,7 +1164,7 @@ func (o *DcimFrontPortTemplatesListParams) WriteToRequest(r runtime.ClientReques
 		qDevicetypeIDn := qrDevicetypeIDn
 		if qDevicetypeIDn != "" {
 
-			if err := r.SetQueryParam("devicetype_id__n", qDevicetypeIDn); err != nil {
+			if err := r.SetQueryParam("device_type_id__n", qDevicetypeIDn); err != nil {
 				return err
 			}
 		}
@@ -1402,7 +1402,7 @@ func (o *DcimFrontPortTemplatesListParams) WriteToRequest(r runtime.ClientReques
 		qModuletypeID := qrModuletypeID
 		if qModuletypeID != "" {
 
-			if err := r.SetQueryParam("moduletype_id", qModuletypeID); err != nil {
+			if err := r.SetQueryParam("module_type_id", qModuletypeID); err != nil {
 				return err
 			}
 		}
@@ -1419,7 +1419,7 @@ func (o *DcimFrontPortTemplatesListParams) WriteToRequest(r runtime.ClientReques
 		qModuletypeIDn := qrModuletypeIDn
 		if qModuletypeIDn != "" {
 
-			if err := r.SetQueryParam("moduletype_id__n", qModuletypeIDn); err != nil {
+			if err := r.SetQueryParam("module_type_id__n", qModuletypeIDn); err != nil {
 				return err
 			}
 		}

--- a/netbox/client/dcim/dcim_interface_templates_list_parameters.go
+++ b/netbox/client/dcim/dcim_interface_templates_list_parameters.go
@@ -876,7 +876,7 @@ func (o *DcimInterfaceTemplatesListParams) WriteToRequest(r runtime.ClientReques
 		qDevicetypeID := qrDevicetypeID
 		if qDevicetypeID != "" {
 
-			if err := r.SetQueryParam("devicetype_id", qDevicetypeID); err != nil {
+			if err := r.SetQueryParam("device_type_id", qDevicetypeID); err != nil {
 				return err
 			}
 		}
@@ -893,7 +893,7 @@ func (o *DcimInterfaceTemplatesListParams) WriteToRequest(r runtime.ClientReques
 		qDevicetypeIDn := qrDevicetypeIDn
 		if qDevicetypeIDn != "" {
 
-			if err := r.SetQueryParam("devicetype_id__n", qDevicetypeIDn); err != nil {
+			if err := r.SetQueryParam("device_type_id__n", qDevicetypeIDn); err != nil {
 				return err
 			}
 		}
@@ -1148,7 +1148,7 @@ func (o *DcimInterfaceTemplatesListParams) WriteToRequest(r runtime.ClientReques
 		qModuletypeID := qrModuletypeID
 		if qModuletypeID != "" {
 
-			if err := r.SetQueryParam("moduletype_id", qModuletypeID); err != nil {
+			if err := r.SetQueryParam("module_type_id", qModuletypeID); err != nil {
 				return err
 			}
 		}
@@ -1165,7 +1165,7 @@ func (o *DcimInterfaceTemplatesListParams) WriteToRequest(r runtime.ClientReques
 		qModuletypeIDn := qrModuletypeIDn
 		if qModuletypeIDn != "" {
 
-			if err := r.SetQueryParam("moduletype_id__n", qModuletypeIDn); err != nil {
+			if err := r.SetQueryParam("module_type_id__n", qModuletypeIDn); err != nil {
 				return err
 			}
 		}

--- a/netbox/client/dcim/dcim_inventory_item_templates_list_parameters.go
+++ b/netbox/client/dcim/dcim_inventory_item_templates_list_parameters.go
@@ -1446,7 +1446,7 @@ func (o *DcimInventoryItemTemplatesListParams) WriteToRequest(r runtime.ClientRe
 		qDevicetypeID := qrDevicetypeID
 		if qDevicetypeID != "" {
 
-			if err := r.SetQueryParam("devicetype_id", qDevicetypeID); err != nil {
+			if err := r.SetQueryParam("device_type_id", qDevicetypeID); err != nil {
 				return err
 			}
 		}
@@ -1463,7 +1463,7 @@ func (o *DcimInventoryItemTemplatesListParams) WriteToRequest(r runtime.ClientRe
 		qDevicetypeIDn := qrDevicetypeIDn
 		if qDevicetypeIDn != "" {
 
-			if err := r.SetQueryParam("devicetype_id__n", qDevicetypeIDn); err != nil {
+			if err := r.SetQueryParam("device_type_id__n", qDevicetypeIDn); err != nil {
 				return err
 			}
 		}

--- a/netbox/client/dcim/dcim_module_bay_templates_list_parameters.go
+++ b/netbox/client/dcim/dcim_module_bay_templates_list_parameters.go
@@ -750,7 +750,7 @@ func (o *DcimModuleBayTemplatesListParams) WriteToRequest(r runtime.ClientReques
 		qDevicetypeID := qrDevicetypeID
 		if qDevicetypeID != "" {
 
-			if err := r.SetQueryParam("devicetype_id", qDevicetypeID); err != nil {
+			if err := r.SetQueryParam("device_type_id", qDevicetypeID); err != nil {
 				return err
 			}
 		}
@@ -767,7 +767,7 @@ func (o *DcimModuleBayTemplatesListParams) WriteToRequest(r runtime.ClientReques
 		qDevicetypeIDn := qrDevicetypeIDn
 		if qDevicetypeIDn != "" {
 
-			if err := r.SetQueryParam("devicetype_id__n", qDevicetypeIDn); err != nil {
+			if err := r.SetQueryParam("device_type_id__n", qDevicetypeIDn); err != nil {
 				return err
 			}
 		}

--- a/netbox/client/dcim/dcim_power_outlet_templates_list_parameters.go
+++ b/netbox/client/dcim/dcim_power_outlet_templates_list_parameters.go
@@ -834,7 +834,7 @@ func (o *DcimPowerOutletTemplatesListParams) WriteToRequest(r runtime.ClientRequ
 		qDevicetypeID := qrDevicetypeID
 		if qDevicetypeID != "" {
 
-			if err := r.SetQueryParam("devicetype_id", qDevicetypeID); err != nil {
+			if err := r.SetQueryParam("device_type_id", qDevicetypeID); err != nil {
 				return err
 			}
 		}
@@ -851,7 +851,7 @@ func (o *DcimPowerOutletTemplatesListParams) WriteToRequest(r runtime.ClientRequ
 		qDevicetypeIDn := qrDevicetypeIDn
 		if qDevicetypeIDn != "" {
 
-			if err := r.SetQueryParam("devicetype_id__n", qDevicetypeIDn); err != nil {
+			if err := r.SetQueryParam("device_type_id__n", qDevicetypeIDn); err != nil {
 				return err
 			}
 		}
@@ -1123,7 +1123,7 @@ func (o *DcimPowerOutletTemplatesListParams) WriteToRequest(r runtime.ClientRequ
 		qModuletypeID := qrModuletypeID
 		if qModuletypeID != "" {
 
-			if err := r.SetQueryParam("moduletype_id", qModuletypeID); err != nil {
+			if err := r.SetQueryParam("module_type_id", qModuletypeID); err != nil {
 				return err
 			}
 		}
@@ -1140,7 +1140,7 @@ func (o *DcimPowerOutletTemplatesListParams) WriteToRequest(r runtime.ClientRequ
 		qModuletypeIDn := qrModuletypeIDn
 		if qModuletypeIDn != "" {
 
-			if err := r.SetQueryParam("moduletype_id__n", qModuletypeIDn); err != nil {
+			if err := r.SetQueryParam("module_type_id__n", qModuletypeIDn); err != nil {
 				return err
 			}
 		}

--- a/netbox/client/dcim/dcim_power_port_templates_list_parameters.go
+++ b/netbox/client/dcim/dcim_power_port_templates_list_parameters.go
@@ -1076,7 +1076,7 @@ func (o *DcimPowerPortTemplatesListParams) WriteToRequest(r runtime.ClientReques
 		qDevicetypeID := qrDevicetypeID
 		if qDevicetypeID != "" {
 
-			if err := r.SetQueryParam("devicetype_id", qDevicetypeID); err != nil {
+			if err := r.SetQueryParam("device_type_id", qDevicetypeID); err != nil {
 				return err
 			}
 		}
@@ -1093,7 +1093,7 @@ func (o *DcimPowerPortTemplatesListParams) WriteToRequest(r runtime.ClientReques
 		qDevicetypeIDn := qrDevicetypeIDn
 		if qDevicetypeIDn != "" {
 
-			if err := r.SetQueryParam("devicetype_id__n", qDevicetypeIDn); err != nil {
+			if err := r.SetQueryParam("device_type_id__n", qDevicetypeIDn); err != nil {
 				return err
 			}
 		}
@@ -1433,7 +1433,7 @@ func (o *DcimPowerPortTemplatesListParams) WriteToRequest(r runtime.ClientReques
 		qModuletypeID := qrModuletypeID
 		if qModuletypeID != "" {
 
-			if err := r.SetQueryParam("moduletype_id", qModuletypeID); err != nil {
+			if err := r.SetQueryParam("module_type_id", qModuletypeID); err != nil {
 				return err
 			}
 		}
@@ -1450,7 +1450,7 @@ func (o *DcimPowerPortTemplatesListParams) WriteToRequest(r runtime.ClientReques
 		qModuletypeIDn := qrModuletypeIDn
 		if qModuletypeIDn != "" {
 
-			if err := r.SetQueryParam("moduletype_id__n", qModuletypeIDn); err != nil {
+			if err := r.SetQueryParam("module_type_id__n", qModuletypeIDn); err != nil {
 				return err
 			}
 		}

--- a/netbox/client/dcim/dcim_rear_port_templates_list_parameters.go
+++ b/netbox/client/dcim/dcim_rear_port_templates_list_parameters.go
@@ -1231,7 +1231,7 @@ func (o *DcimRearPortTemplatesListParams) WriteToRequest(r runtime.ClientRequest
 		qDevicetypeID := qrDevicetypeID
 		if qDevicetypeID != "" {
 
-			if err := r.SetQueryParam("devicetype_id", qDevicetypeID); err != nil {
+			if err := r.SetQueryParam("device_type_id", qDevicetypeID); err != nil {
 				return err
 			}
 		}
@@ -1248,7 +1248,7 @@ func (o *DcimRearPortTemplatesListParams) WriteToRequest(r runtime.ClientRequest
 		qDevicetypeIDn := qrDevicetypeIDn
 		if qDevicetypeIDn != "" {
 
-			if err := r.SetQueryParam("devicetype_id__n", qDevicetypeIDn); err != nil {
+			if err := r.SetQueryParam("device_type_id__n", qDevicetypeIDn); err != nil {
 				return err
 			}
 		}
@@ -1486,7 +1486,7 @@ func (o *DcimRearPortTemplatesListParams) WriteToRequest(r runtime.ClientRequest
 		qModuletypeID := qrModuletypeID
 		if qModuletypeID != "" {
 
-			if err := r.SetQueryParam("moduletype_id", qModuletypeID); err != nil {
+			if err := r.SetQueryParam("module_type_id", qModuletypeID); err != nil {
 				return err
 			}
 		}
@@ -1503,7 +1503,7 @@ func (o *DcimRearPortTemplatesListParams) WriteToRequest(r runtime.ClientRequest
 		qModuletypeIDn := qrModuletypeIDn
 		if qModuletypeIDn != "" {
 
-			if err := r.SetQueryParam("moduletype_id__n", qModuletypeIDn); err != nil {
+			if err := r.SetQueryParam("module_type_id__n", qModuletypeIDn); err != nil {
 				return err
 			}
 		}

--- a/netbox/client/ipam/ipam_ip_ranges_available_ips_create_parameters.go
+++ b/netbox/client/ipam/ipam_ip_ranges_available_ips_create_parameters.go
@@ -80,7 +80,7 @@ IpamIPRangesAvailableIpsCreateParams contains all the parameters to send to the 
 type IpamIPRangesAvailableIpsCreateParams struct {
 
 	// Data.
-	Data []*models.AvailableIP
+	Data []*models.WritableAvailableIP
 
 	/* ID.
 
@@ -142,13 +142,13 @@ func (o *IpamIPRangesAvailableIpsCreateParams) SetHTTPClient(client *http.Client
 }
 
 // WithData adds the data to the ipam ip ranges available ips create params
-func (o *IpamIPRangesAvailableIpsCreateParams) WithData(data []*models.AvailableIP) *IpamIPRangesAvailableIpsCreateParams {
+func (o *IpamIPRangesAvailableIpsCreateParams) WithData(data []*models.WritableAvailableIP) *IpamIPRangesAvailableIpsCreateParams {
 	o.SetData(data)
 	return o
 }
 
 // SetData adds the data to the ipam ip ranges available ips create params
-func (o *IpamIPRangesAvailableIpsCreateParams) SetData(data []*models.AvailableIP) {
+func (o *IpamIPRangesAvailableIpsCreateParams) SetData(data []*models.WritableAvailableIP) {
 	o.Data = data
 }
 

--- a/netbox/client/ipam/ipam_prefixes_available_ips_create_parameters.go
+++ b/netbox/client/ipam/ipam_prefixes_available_ips_create_parameters.go
@@ -80,7 +80,7 @@ IpamPrefixesAvailableIpsCreateParams contains all the parameters to send to the 
 type IpamPrefixesAvailableIpsCreateParams struct {
 
 	// Data.
-	Data []*models.AvailableIP
+	Data []*models.WritableAvailableIP
 
 	/* ID.
 
@@ -142,13 +142,13 @@ func (o *IpamPrefixesAvailableIpsCreateParams) SetHTTPClient(client *http.Client
 }
 
 // WithData adds the data to the ipam prefixes available ips create params
-func (o *IpamPrefixesAvailableIpsCreateParams) WithData(data []*models.AvailableIP) *IpamPrefixesAvailableIpsCreateParams {
+func (o *IpamPrefixesAvailableIpsCreateParams) WithData(data []*models.WritableAvailableIP) *IpamPrefixesAvailableIpsCreateParams {
 	o.SetData(data)
 	return o
 }
 
 // SetData adds the data to the ipam prefixes available ips create params
-func (o *IpamPrefixesAvailableIpsCreateParams) SetData(data []*models.AvailableIP) {
+func (o *IpamPrefixesAvailableIpsCreateParams) SetData(data []*models.WritableAvailableIP) {
 	o.Data = data
 }
 

--- a/netbox/models/device_type.go
+++ b/netbox/models/device_type.go
@@ -50,6 +50,9 @@ type DeviceType struct {
 	// Custom fields
 	CustomFields interface{} `json:"custom_fields,omitempty"`
 
+	// default platform
+	DefaultPlatform *NestedPlatform `json:"default_platform,omitempty"`
+
 	// Description
 	// Max Length: 200
 	Description string `json:"description,omitempty"`
@@ -57,6 +60,9 @@ type DeviceType struct {
 	// Device count
 	// Read Only: true
 	DeviceCount int64 `json:"device_count,omitempty"`
+
+	// Exclude from utilization
+	ExcludeFromUtilization bool `json:"exclude_from_utilization,omitempty"`
 
 	// Display
 	// Read Only: true

--- a/netbox/models/writable_available_ip.go
+++ b/netbox/models/writable_available_ip.go
@@ -42,6 +42,9 @@ type WritableAvailableIP struct {
 	// Family
 	// Read Only: true
 	Family int64 `json:"family,omitempty"`
+
+	// Tenant
+	Tenant int64 `json:"tenant,omitempty"`
 }
 
 // Validate validates this writable available IP

--- a/netbox/models/writable_custom_field.go
+++ b/netbox/models/writable_custom_field.go
@@ -129,7 +129,7 @@ type WritableCustomField struct {
 	//
 	// Specifies the visibility of custom field in the UI
 	// Enum: ["read-write","read-only","hidden"]
-	UIVisibility string `json:"ui_visibility,omitempty"`
+	UIVisibility string `json:"ui_visible,omitempty"`
 
 	// Url
 	// Read Only: true

--- a/netbox/models/writable_device_type.go
+++ b/netbox/models/writable_device_type.go
@@ -51,6 +51,9 @@ type WritableDeviceType struct {
 	// Custom fields
 	CustomFields interface{} `json:"custom_fields,omitempty"`
 
+	// Default platform
+	DefaultPlatform *int64 `json:"default_platform,omitempty"`
+
 	// Description
 	// Max Length: 200
 	Description string `json:"description,omitempty"`
@@ -58,6 +61,9 @@ type WritableDeviceType struct {
 	// Device count
 	// Read Only: true
 	DeviceCount int64 `json:"device_count,omitempty"`
+
+	// Exclude from utilization
+	ExcludeFromUtilization bool `json:"exclude_from_utilization"`
 
 	// Display
 	// Read Only: true


### PR DESCRIPTION
The UIVisibility field on WritableCustomField had the wrong JSON tag (ui_visibility) causing the value to be silently ignored by the NetBox API on create/update requests.

The NetBox read API returns the field as ui_visibility (wrapped in a {value, label} object), but the write API (POST/PATCH) expects the field as ui_visible (plain string). This asymmetry in the NetBox API meant our model was correct for reads but wrong for writes.

Co-author: Cursor 