### PR TITLE
feat: add mark_populated/utilized to ip_range

### DIFF
--- a/netbox/client/ipam/ipam_ip_ranges_list_parameters.go
+++ b/netbox/client/ipam/ipam_ip_ranges_list_parameters.go
@@ -179,6 +179,12 @@ type IpamIPRangesListParams struct {
 	*/
 	Limit *int64
 
+	// MarkPopulated.
+	MarkPopulated *string
+
+	// MarkUtilized.
+	MarkUtilized *string
+
 	/* Offset.
 
 	   The initial index from which to return the results.
@@ -671,6 +677,28 @@ func (o *IpamIPRangesListParams) WithLimit(limit *int64) *IpamIPRangesListParams
 // SetLimit adds the limit to the ipam ip ranges list params
 func (o *IpamIPRangesListParams) SetLimit(limit *int64) {
 	o.Limit = limit
+}
+
+// WithMarkPopulated adds the markPopulated to the ipam ip ranges list params
+func (o *IpamIPRangesListParams) WithMarkPopulated(markPopulated *string) *IpamIPRangesListParams {
+	o.SetMarkPopulated(markPopulated)
+	return o
+}
+
+// SetMarkPopulated adds the markPopulated to the ipam ip ranges list params
+func (o *IpamIPRangesListParams) SetMarkPopulated(markPopulated *string) {
+	o.MarkPopulated = markPopulated
+}
+
+// WithMarkUtilized adds the markUtilized to the ipam ip ranges list params
+func (o *IpamIPRangesListParams) WithMarkUtilized(markUtilized *string) *IpamIPRangesListParams {
+	o.SetMarkUtilized(markUtilized)
+	return o
+}
+
+// SetMarkUtilized adds the markUtilized to the ipam ip ranges list params
+func (o *IpamIPRangesListParams) SetMarkUtilized(markUtilized *string) {
+	o.MarkUtilized = markUtilized
 }
 
 // WithOffset adds the offset to the ipam ip ranges list params
@@ -1501,6 +1529,40 @@ func (o *IpamIPRangesListParams) WriteToRequest(r runtime.ClientRequest, reg str
 		if qLimit != "" {
 
 			if err := r.SetQueryParam("limit", qLimit); err != nil {
+				return err
+			}
+		}
+	}
+
+	if o.MarkPopulated != nil {
+
+		// query param mark_populated
+		var qrMarkPopulated string
+
+		if o.MarkPopulated != nil {
+			qrMarkPopulated = *o.MarkPopulated
+		}
+		qMarkPopulated := qrMarkPopulated
+		if qMarkPopulated != "" {
+
+			if err := r.SetQueryParam("mark_populated", qMarkPopulated); err != nil {
+				return err
+			}
+		}
+	}
+
+	if o.MarkUtilized != nil {
+
+		// query param mark_utilized
+		var qrMarkUtilized string
+
+		if o.MarkUtilized != nil {
+			qrMarkUtilized = *o.MarkUtilized
+		}
+		qMarkUtilized := qrMarkUtilized
+		if qMarkUtilized != "" {
+
+			if err := r.SetQueryParam("mark_utilized", qMarkUtilized); err != nil {
 				return err
 			}
 		}

--- a/netbox/models/ip_range.go
+++ b/netbox/models/ip_range.go
@@ -77,6 +77,12 @@ type IPRange struct {
 	// Format: date-time
 	LastUpdated *strfmt.DateTime `json:"last_updated,omitempty"`
 
+	// Mark populated
+	MarkPopulated bool `json:"mark_populated,omitempty"`
+
+	// Mark utilized
+	MarkUtilized bool `json:"mark_utilized,omitempty"`
+
 	// role
 	Role *NestedRole `json:"role,omitempty"`
 

--- a/netbox/models/writable_ip_range.go
+++ b/netbox/models/writable_ip_range.go
@@ -78,6 +78,12 @@ type WritableIPRange struct {
 	// Format: date-time
 	LastUpdated *strfmt.DateTime `json:"last_updated,omitempty"`
 
+	// Mark populated
+	MarkPopulated bool `json:"mark_populated"`
+
+	// Mark utilized
+	MarkUtilized bool `json:"mark_utilized"`
+
 	// Role
 	//
 	// The primary function of this range

--- a/swagger.processed.json
+++ b/swagger.processed.json
@@ -45509,6 +45509,20 @@
             "type": "string"
           },
           {
+            "name": "mark_populated",
+            "in": "query",
+            "description": "",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "mark_utilized",
+            "in": "query",
+            "description": "",
+            "required": false,
+            "type": "string"
+          },
+          {
             "name": "id__n",
             "in": "query",
             "description": "",
@@ -88047,6 +88061,14 @@
         "role": {
           "$ref": "#/definitions/NestedRole"
         },
+        "mark_populated": {
+          "title": "Mark populated",
+          "type": "boolean"
+        },
+        "mark_utilized": {
+          "title": "Mark utilized",
+          "type": "boolean"
+        },
         "description": {
           "title": "Description",
           "type": "string",
@@ -88156,6 +88178,16 @@
           "description": "The primary function of this range",
           "type": "integer",
           "x-nullable": true
+        },
+        "mark_populated": {
+          "title": "Mark populated",
+          "type": "boolean",
+          "x-omitempty": false
+        },
+        "mark_utilized": {
+          "title": "Mark utilized",
+          "type": "boolean",
+          "x-omitempty": false
         },
         "description": {
           "title": "Description",


### PR DESCRIPTION
Add `mark_populated` and `mark_utilized` parameters to ip-ranges.

I will open a corresponding PR to the Terraform provider later.