### PR TITLE
fix: replace int64 with NestedCable in NestedPowerPort

### DIFF
--- a/netbox/models/nested_power_port.go
+++ b/netbox/models/nested_power_port.go
@@ -38,8 +38,8 @@ type NestedPowerPort struct {
 	// Read Only: true
 	Occupied *bool `json:"_occupied,omitempty"`
 
-	// Cable
-	Cable *int64 `json:"cable,omitempty"`
+	// cable
+	Cable *NestedCable `json:"cable,omitempty"`
 
 	// device
 	Device *NestedDevice `json:"device,omitempty"`
@@ -68,6 +68,10 @@ type NestedPowerPort struct {
 func (m *NestedPowerPort) Validate(formats strfmt.Registry) error {
 	var res []error
 
+	if err := m.validateCable(formats); err != nil {
+		res = append(res, err)
+	}
+
 	if err := m.validateDevice(formats); err != nil {
 		res = append(res, err)
 	}
@@ -83,6 +87,25 @@ func (m *NestedPowerPort) Validate(formats strfmt.Registry) error {
 	if len(res) > 0 {
 		return errors.CompositeValidationError(res...)
 	}
+	return nil
+}
+
+func (m *NestedPowerPort) validateCable(formats strfmt.Registry) error {
+	if swag.IsZero(m.Cable) { // not required
+		return nil
+	}
+
+	if m.Cable != nil {
+		if err := m.Cable.Validate(formats); err != nil {
+			if ve, ok := err.(*errors.Validation); ok {
+				return ve.ValidateName("cable")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("cable")
+			}
+			return err
+		}
+	}
+
 	return nil
 }
 
@@ -142,6 +165,10 @@ func (m *NestedPowerPort) ContextValidate(ctx context.Context, formats strfmt.Re
 		res = append(res, err)
 	}
 
+	if err := m.contextValidateCable(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
 	if err := m.contextValidateDevice(ctx, formats); err != nil {
 		res = append(res, err)
 	}
@@ -168,6 +195,27 @@ func (m *NestedPowerPort) contextValidateOccupied(ctx context.Context, formats s
 
 	if err := validate.ReadOnly(ctx, "_occupied", "body", m.Occupied); err != nil {
 		return err
+	}
+
+	return nil
+}
+
+func (m *NestedPowerPort) contextValidateCable(ctx context.Context, formats strfmt.Registry) error {
+
+	if m.Cable != nil {
+
+		if swag.IsZero(m.Cable) { // not required
+			return nil
+		}
+
+		if err := m.Cable.ContextValidate(ctx, formats); err != nil {
+			if ve, ok := err.(*errors.Validation); ok {
+				return ve.ValidateName("cable")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("cable")
+			}
+			return err
+		}
 	}
 
 	return nil

--- a/swagger.processed.json
+++ b/swagger.processed.json
@@ -80105,9 +80105,7 @@
           "minLength": 1
         },
         "cable": {
-          "title": "Cable",
-          "type": "integer",
-          "x-nullable": true
+          "$ref": "#/definitions/NestedCable"
         },
         "_occupied": {
           "title": "occupied",


### PR DESCRIPTION
I get this error:

```
Error: json: cannot unmarshal object into Go struct field NestedPowerPort.power_port.cable of type int64
│
│   with netbox_device_power_outlet.p1,
│   on main.tf line 102, in resource "netbox_device_power_outlet" "p1":
│  102: resource "netbox_device_power_outlet" "p1" {
```

The `NestedPowerPort` model defines the `Cable` as `int64`. Changed to `NestedCable`, as the API returns the cable JSON, not only the `id`.