### PR TITLE
feat: add owners and owner-groups client bindings

### DIFF
--- a/netbox/client/users/users_client.go
+++ b/netbox/client/users/users_client.go
@@ -83,6 +83,30 @@ type ClientService interface {
 
 	UsersGroupsUpdate(params *UsersGroupsUpdateParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*UsersGroupsUpdateOK, error)
 
+	UsersOwnerGroupsCreate(params *UsersOwnerGroupsCreateParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*UsersOwnerGroupsCreateCreated, error)
+
+	UsersOwnerGroupsDelete(params *UsersOwnerGroupsDeleteParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*UsersOwnerGroupsDeleteNoContent, error)
+
+	UsersOwnerGroupsList(params *UsersOwnerGroupsListParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*UsersOwnerGroupsListOK, error)
+
+	UsersOwnerGroupsPartialUpdate(params *UsersOwnerGroupsPartialUpdateParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*UsersOwnerGroupsPartialUpdateOK, error)
+
+	UsersOwnerGroupsRead(params *UsersOwnerGroupsReadParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*UsersOwnerGroupsReadOK, error)
+
+	UsersOwnerGroupsUpdate(params *UsersOwnerGroupsUpdateParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*UsersOwnerGroupsUpdateOK, error)
+
+	UsersOwnersCreate(params *UsersOwnersCreateParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*UsersOwnersCreateCreated, error)
+
+	UsersOwnersDelete(params *UsersOwnersDeleteParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*UsersOwnersDeleteNoContent, error)
+
+	UsersOwnersList(params *UsersOwnersListParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*UsersOwnersListOK, error)
+
+	UsersOwnersPartialUpdate(params *UsersOwnersPartialUpdateParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*UsersOwnersPartialUpdateOK, error)
+
+	UsersOwnersRead(params *UsersOwnersReadParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*UsersOwnersReadOK, error)
+
+	UsersOwnersUpdate(params *UsersOwnersUpdateParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*UsersOwnersUpdateOK, error)
+
 	UsersPermissionsCreate(params *UsersPermissionsCreateParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*UsersPermissionsCreateCreated, error)
 
 	UsersPermissionsDelete(params *UsersPermissionsDeleteParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*UsersPermissionsDeleteNoContent, error)
@@ -387,6 +411,462 @@ func (a *Client) UsersGroupsUpdate(params *UsersGroupsUpdateParams, authInfo run
 	}
 	// unexpected success response
 	unexpectedSuccess := result.(*UsersGroupsUpdateDefault)
+	return nil, runtime.NewAPIError("unexpected success response: content available as default response in error", unexpectedSuccess, unexpectedSuccess.Code())
+}
+
+/*
+UsersOwnerGroupsCreate users owner groups create API API
+*/
+func (a *Client) UsersOwnerGroupsCreate(params *UsersOwnerGroupsCreateParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*UsersOwnerGroupsCreateCreated, error) {
+	// TODO: Validate the params before sending
+	if params == nil {
+		params = NewUsersOwnerGroupsCreateParams()
+	}
+	op := &runtime.ClientOperation{
+		ID:                 "users_owner_groups_create",
+		Method:             "POST",
+		PathPattern:        "/users/owner-groups/",
+		ProducesMediaTypes: []string{"application/json"},
+		ConsumesMediaTypes: []string{"application/json"},
+		Schemes:            []string{"http"},
+		Params:             params,
+		Reader:             &UsersOwnerGroupsCreateReader{formats: a.formats},
+		AuthInfo:           authInfo,
+		Context:            params.Context,
+		Client:             params.HTTPClient,
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
+	if err != nil {
+		return nil, err
+	}
+	success, ok := result.(*UsersOwnerGroupsCreateCreated)
+	if ok {
+		return success, nil
+	}
+	// unexpected success response
+	unexpectedSuccess := result.(*UsersOwnerGroupsCreateDefault)
+	return nil, runtime.NewAPIError("unexpected success response: content available as default response in error", unexpectedSuccess, unexpectedSuccess.Code())
+}
+
+/*
+UsersOwnerGroupsDelete users owner groups delete API API
+*/
+func (a *Client) UsersOwnerGroupsDelete(params *UsersOwnerGroupsDeleteParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*UsersOwnerGroupsDeleteNoContent, error) {
+	// TODO: Validate the params before sending
+	if params == nil {
+		params = NewUsersOwnerGroupsDeleteParams()
+	}
+	op := &runtime.ClientOperation{
+		ID:                 "users_owner_groups_delete",
+		Method:             "DELETE",
+		PathPattern:        "/users/owner-groups/{id}/",
+		ProducesMediaTypes: []string{"application/json"},
+		ConsumesMediaTypes: []string{"application/json"},
+		Schemes:            []string{"http"},
+		Params:             params,
+		Reader:             &UsersOwnerGroupsDeleteReader{formats: a.formats},
+		AuthInfo:           authInfo,
+		Context:            params.Context,
+		Client:             params.HTTPClient,
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
+	if err != nil {
+		return nil, err
+	}
+	success, ok := result.(*UsersOwnerGroupsDeleteNoContent)
+	if ok {
+		return success, nil
+	}
+	// unexpected success response
+	unexpectedSuccess := result.(*UsersOwnerGroupsDeleteDefault)
+	return nil, runtime.NewAPIError("unexpected success response: content available as default response in error", unexpectedSuccess, unexpectedSuccess.Code())
+}
+
+/*
+UsersOwnerGroupsList users owner groups list API API
+*/
+func (a *Client) UsersOwnerGroupsList(params *UsersOwnerGroupsListParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*UsersOwnerGroupsListOK, error) {
+	// TODO: Validate the params before sending
+	if params == nil {
+		params = NewUsersOwnerGroupsListParams()
+	}
+	op := &runtime.ClientOperation{
+		ID:                 "users_owner_groups_list",
+		Method:             "GET",
+		PathPattern:        "/users/owner-groups/",
+		ProducesMediaTypes: []string{"application/json"},
+		ConsumesMediaTypes: []string{"application/json"},
+		Schemes:            []string{"http"},
+		Params:             params,
+		Reader:             &UsersOwnerGroupsListReader{formats: a.formats},
+		AuthInfo:           authInfo,
+		Context:            params.Context,
+		Client:             params.HTTPClient,
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
+	if err != nil {
+		return nil, err
+	}
+	success, ok := result.(*UsersOwnerGroupsListOK)
+	if ok {
+		return success, nil
+	}
+	// unexpected success response
+	unexpectedSuccess := result.(*UsersOwnerGroupsListDefault)
+	return nil, runtime.NewAPIError("unexpected success response: content available as default response in error", unexpectedSuccess, unexpectedSuccess.Code())
+}
+
+/*
+UsersOwnerGroupsPartialUpdate users owner groups partial update API API
+*/
+func (a *Client) UsersOwnerGroupsPartialUpdate(params *UsersOwnerGroupsPartialUpdateParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*UsersOwnerGroupsPartialUpdateOK, error) {
+	// TODO: Validate the params before sending
+	if params == nil {
+		params = NewUsersOwnerGroupsPartialUpdateParams()
+	}
+	op := &runtime.ClientOperation{
+		ID:                 "users_owner_groups_partial_update",
+		Method:             "PATCH",
+		PathPattern:        "/users/owner-groups/{id}/",
+		ProducesMediaTypes: []string{"application/json"},
+		ConsumesMediaTypes: []string{"application/json"},
+		Schemes:            []string{"http"},
+		Params:             params,
+		Reader:             &UsersOwnerGroupsPartialUpdateReader{formats: a.formats},
+		AuthInfo:           authInfo,
+		Context:            params.Context,
+		Client:             params.HTTPClient,
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
+	if err != nil {
+		return nil, err
+	}
+	success, ok := result.(*UsersOwnerGroupsPartialUpdateOK)
+	if ok {
+		return success, nil
+	}
+	// unexpected success response
+	unexpectedSuccess := result.(*UsersOwnerGroupsPartialUpdateDefault)
+	return nil, runtime.NewAPIError("unexpected success response: content available as default response in error", unexpectedSuccess, unexpectedSuccess.Code())
+}
+
+/*
+UsersOwnerGroupsRead users owner groups read API API
+*/
+func (a *Client) UsersOwnerGroupsRead(params *UsersOwnerGroupsReadParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*UsersOwnerGroupsReadOK, error) {
+	// TODO: Validate the params before sending
+	if params == nil {
+		params = NewUsersOwnerGroupsReadParams()
+	}
+	op := &runtime.ClientOperation{
+		ID:                 "users_owner_groups_read",
+		Method:             "GET",
+		PathPattern:        "/users/owner-groups/{id}/",
+		ProducesMediaTypes: []string{"application/json"},
+		ConsumesMediaTypes: []string{"application/json"},
+		Schemes:            []string{"http"},
+		Params:             params,
+		Reader:             &UsersOwnerGroupsReadReader{formats: a.formats},
+		AuthInfo:           authInfo,
+		Context:            params.Context,
+		Client:             params.HTTPClient,
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
+	if err != nil {
+		return nil, err
+	}
+	success, ok := result.(*UsersOwnerGroupsReadOK)
+	if ok {
+		return success, nil
+	}
+	// unexpected success response
+	unexpectedSuccess := result.(*UsersOwnerGroupsReadDefault)
+	return nil, runtime.NewAPIError("unexpected success response: content available as default response in error", unexpectedSuccess, unexpectedSuccess.Code())
+}
+
+/*
+UsersOwnerGroupsUpdate users owner groups update API API
+*/
+func (a *Client) UsersOwnerGroupsUpdate(params *UsersOwnerGroupsUpdateParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*UsersOwnerGroupsUpdateOK, error) {
+	// TODO: Validate the params before sending
+	if params == nil {
+		params = NewUsersOwnerGroupsUpdateParams()
+	}
+	op := &runtime.ClientOperation{
+		ID:                 "users_owner_groups_update",
+		Method:             "PUT",
+		PathPattern:        "/users/owner-groups/{id}/",
+		ProducesMediaTypes: []string{"application/json"},
+		ConsumesMediaTypes: []string{"application/json"},
+		Schemes:            []string{"http"},
+		Params:             params,
+		Reader:             &UsersOwnerGroupsUpdateReader{formats: a.formats},
+		AuthInfo:           authInfo,
+		Context:            params.Context,
+		Client:             params.HTTPClient,
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
+	if err != nil {
+		return nil, err
+	}
+	success, ok := result.(*UsersOwnerGroupsUpdateOK)
+	if ok {
+		return success, nil
+	}
+	// unexpected success response
+	unexpectedSuccess := result.(*UsersOwnerGroupsUpdateDefault)
+	return nil, runtime.NewAPIError("unexpected success response: content available as default response in error", unexpectedSuccess, unexpectedSuccess.Code())
+}
+
+/*
+UsersOwnersCreate users owners create API API
+*/
+func (a *Client) UsersOwnersCreate(params *UsersOwnersCreateParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*UsersOwnersCreateCreated, error) {
+	// TODO: Validate the params before sending
+	if params == nil {
+		params = NewUsersOwnersCreateParams()
+	}
+	op := &runtime.ClientOperation{
+		ID:                 "users_owners_create",
+		Method:             "POST",
+		PathPattern:        "/users/owners/",
+		ProducesMediaTypes: []string{"application/json"},
+		ConsumesMediaTypes: []string{"application/json"},
+		Schemes:            []string{"http"},
+		Params:             params,
+		Reader:             &UsersOwnersCreateReader{formats: a.formats},
+		AuthInfo:           authInfo,
+		Context:            params.Context,
+		Client:             params.HTTPClient,
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
+	if err != nil {
+		return nil, err
+	}
+	success, ok := result.(*UsersOwnersCreateCreated)
+	if ok {
+		return success, nil
+	}
+	// unexpected success response
+	unexpectedSuccess := result.(*UsersOwnersCreateDefault)
+	return nil, runtime.NewAPIError("unexpected success response: content available as default response in error", unexpectedSuccess, unexpectedSuccess.Code())
+}
+
+/*
+UsersOwnersDelete users owners delete API API
+*/
+func (a *Client) UsersOwnersDelete(params *UsersOwnersDeleteParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*UsersOwnersDeleteNoContent, error) {
+	// TODO: Validate the params before sending
+	if params == nil {
+		params = NewUsersOwnersDeleteParams()
+	}
+	op := &runtime.ClientOperation{
+		ID:                 "users_owners_delete",
+		Method:             "DELETE",
+		PathPattern:        "/users/owners/{id}/",
+		ProducesMediaTypes: []string{"application/json"},
+		ConsumesMediaTypes: []string{"application/json"},
+		Schemes:            []string{"http"},
+		Params:             params,
+		Reader:             &UsersOwnersDeleteReader{formats: a.formats},
+		AuthInfo:           authInfo,
+		Context:            params.Context,
+		Client:             params.HTTPClient,
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
+	if err != nil {
+		return nil, err
+	}
+	success, ok := result.(*UsersOwnersDeleteNoContent)
+	if ok {
+		return success, nil
+	}
+	// unexpected success response
+	unexpectedSuccess := result.(*UsersOwnersDeleteDefault)
+	return nil, runtime.NewAPIError("unexpected success response: content available as default response in error", unexpectedSuccess, unexpectedSuccess.Code())
+}
+
+/*
+UsersOwnersList users owners list API API
+*/
+func (a *Client) UsersOwnersList(params *UsersOwnersListParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*UsersOwnersListOK, error) {
+	// TODO: Validate the params before sending
+	if params == nil {
+		params = NewUsersOwnersListParams()
+	}
+	op := &runtime.ClientOperation{
+		ID:                 "users_owners_list",
+		Method:             "GET",
+		PathPattern:        "/users/owners/",
+		ProducesMediaTypes: []string{"application/json"},
+		ConsumesMediaTypes: []string{"application/json"},
+		Schemes:            []string{"http"},
+		Params:             params,
+		Reader:             &UsersOwnersListReader{formats: a.formats},
+		AuthInfo:           authInfo,
+		Context:            params.Context,
+		Client:             params.HTTPClient,
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
+	if err != nil {
+		return nil, err
+	}
+	success, ok := result.(*UsersOwnersListOK)
+	if ok {
+		return success, nil
+	}
+	// unexpected success response
+	unexpectedSuccess := result.(*UsersOwnersListDefault)
+	return nil, runtime.NewAPIError("unexpected success response: content available as default response in error", unexpectedSuccess, unexpectedSuccess.Code())
+}
+
+/*
+UsersOwnersPartialUpdate users owners partial update API API
+*/
+func (a *Client) UsersOwnersPartialUpdate(params *UsersOwnersPartialUpdateParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*UsersOwnersPartialUpdateOK, error) {
+	// TODO: Validate the params before sending
+	if params == nil {
+		params = NewUsersOwnersPartialUpdateParams()
+	}
+	op := &runtime.ClientOperation{
+		ID:                 "users_owners_partial_update",
+		Method:             "PATCH",
+		PathPattern:        "/users/owners/{id}/",
+		ProducesMediaTypes: []string{"application/json"},
+		ConsumesMediaTypes: []string{"application/json"},
+		Schemes:            []string{"http"},
+		Params:             params,
+		Reader:             &UsersOwnersPartialUpdateReader{formats: a.formats},
+		AuthInfo:           authInfo,
+		Context:            params.Context,
+		Client:             params.HTTPClient,
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
+	if err != nil {
+		return nil, err
+	}
+	success, ok := result.(*UsersOwnersPartialUpdateOK)
+	if ok {
+		return success, nil
+	}
+	// unexpected success response
+	unexpectedSuccess := result.(*UsersOwnersPartialUpdateDefault)
+	return nil, runtime.NewAPIError("unexpected success response: content available as default response in error", unexpectedSuccess, unexpectedSuccess.Code())
+}
+
+/*
+UsersOwnersRead users owners read API API
+*/
+func (a *Client) UsersOwnersRead(params *UsersOwnersReadParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*UsersOwnersReadOK, error) {
+	// TODO: Validate the params before sending
+	if params == nil {
+		params = NewUsersOwnersReadParams()
+	}
+	op := &runtime.ClientOperation{
+		ID:                 "users_owners_read",
+		Method:             "GET",
+		PathPattern:        "/users/owners/{id}/",
+		ProducesMediaTypes: []string{"application/json"},
+		ConsumesMediaTypes: []string{"application/json"},
+		Schemes:            []string{"http"},
+		Params:             params,
+		Reader:             &UsersOwnersReadReader{formats: a.formats},
+		AuthInfo:           authInfo,
+		Context:            params.Context,
+		Client:             params.HTTPClient,
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
+	if err != nil {
+		return nil, err
+	}
+	success, ok := result.(*UsersOwnersReadOK)
+	if ok {
+		return success, nil
+	}
+	// unexpected success response
+	unexpectedSuccess := result.(*UsersOwnersReadDefault)
+	return nil, runtime.NewAPIError("unexpected success response: content available as default response in error", unexpectedSuccess, unexpectedSuccess.Code())
+}
+
+/*
+UsersOwnersUpdate users owners update API API
+*/
+func (a *Client) UsersOwnersUpdate(params *UsersOwnersUpdateParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*UsersOwnersUpdateOK, error) {
+	// TODO: Validate the params before sending
+	if params == nil {
+		params = NewUsersOwnersUpdateParams()
+	}
+	op := &runtime.ClientOperation{
+		ID:                 "users_owners_update",
+		Method:             "PUT",
+		PathPattern:        "/users/owners/{id}/",
+		ProducesMediaTypes: []string{"application/json"},
+		ConsumesMediaTypes: []string{"application/json"},
+		Schemes:            []string{"http"},
+		Params:             params,
+		Reader:             &UsersOwnersUpdateReader{formats: a.formats},
+		AuthInfo:           authInfo,
+		Context:            params.Context,
+		Client:             params.HTTPClient,
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
+	if err != nil {
+		return nil, err
+	}
+	success, ok := result.(*UsersOwnersUpdateOK)
+	if ok {
+		return success, nil
+	}
+	// unexpected success response
+	unexpectedSuccess := result.(*UsersOwnersUpdateDefault)
 	return nil, runtime.NewAPIError("unexpected success response: content available as default response in error", unexpectedSuccess, unexpectedSuccess.Code())
 }
 

--- a/netbox/client/users/users_owner_groups_create_parameters.go
+++ b/netbox/client/users/users_owner_groups_create_parameters.go
@@ -1,0 +1,164 @@
+// Copyright 2020 The go-netbox Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package users
+
+// This file was manually added to extend the client with NetBox's Owner/OwnerGroup
+// endpoints (netbox-community/netbox users app), which are not yet covered by the
+// upstream swagger-generated client.
+
+import (
+	"context"
+	"net/http"
+	"time"
+
+	"github.com/go-openapi/errors"
+	"github.com/go-openapi/runtime"
+	cr "github.com/go-openapi/runtime/client"
+	"github.com/go-openapi/strfmt"
+
+	"github.com/fbreckle/go-netbox/netbox/models"
+)
+
+// NewUsersOwnerGroupsCreateParams creates a new UsersOwnerGroupsCreateParams object,
+// with the default timeout for this client.
+//
+// Default values are not hydrated, since defaults are normally applied by the API server side.
+//
+// To enforce default values in parameter, use SetDefaults or WithDefaults.
+func NewUsersOwnerGroupsCreateParams() *UsersOwnerGroupsCreateParams {
+	return &UsersOwnerGroupsCreateParams{
+		timeout: cr.DefaultTimeout,
+	}
+}
+
+// NewUsersOwnerGroupsCreateParamsWithTimeout creates a new UsersOwnerGroupsCreateParams object
+// with the ability to set a timeout on a request.
+func NewUsersOwnerGroupsCreateParamsWithTimeout(timeout time.Duration) *UsersOwnerGroupsCreateParams {
+	return &UsersOwnerGroupsCreateParams{
+		timeout: timeout,
+	}
+}
+
+// NewUsersOwnerGroupsCreateParamsWithContext creates a new UsersOwnerGroupsCreateParams object
+// with the ability to set a context for a request.
+func NewUsersOwnerGroupsCreateParamsWithContext(ctx context.Context) *UsersOwnerGroupsCreateParams {
+	return &UsersOwnerGroupsCreateParams{
+		Context: ctx,
+	}
+}
+
+// NewUsersOwnerGroupsCreateParamsWithHTTPClient creates a new UsersOwnerGroupsCreateParams object
+// with the ability to set a custom HTTPClient for a request.
+func NewUsersOwnerGroupsCreateParamsWithHTTPClient(client *http.Client) *UsersOwnerGroupsCreateParams {
+	return &UsersOwnerGroupsCreateParams{
+		HTTPClient: client,
+	}
+}
+
+/*
+UsersOwnerGroupsCreateParams contains all the parameters to send to the API endpoint
+
+	for the users owner groups create operation.
+
+	Typically these are written to a http.Request.
+*/
+type UsersOwnerGroupsCreateParams struct {
+
+	// Data.
+	Data *models.OwnerGroup
+
+	timeout    time.Duration
+	Context    context.Context
+	HTTPClient *http.Client
+}
+
+// WithDefaults hydrates default values in the users owner groups create params (not the query body).
+//
+// All values with no default are reset to their zero value.
+func (o *UsersOwnerGroupsCreateParams) WithDefaults() *UsersOwnerGroupsCreateParams {
+	o.SetDefaults()
+	return o
+}
+
+// SetDefaults hydrates default values in the users owner groups create params (not the query body).
+//
+// All values with no default are reset to their zero value.
+func (o *UsersOwnerGroupsCreateParams) SetDefaults() {
+	// no default values defined for this parameter
+}
+
+// WithTimeout adds the timeout to the users owner groups create params
+func (o *UsersOwnerGroupsCreateParams) WithTimeout(timeout time.Duration) *UsersOwnerGroupsCreateParams {
+	o.SetTimeout(timeout)
+	return o
+}
+
+// SetTimeout adds the timeout to the users owner groups create params
+func (o *UsersOwnerGroupsCreateParams) SetTimeout(timeout time.Duration) {
+	o.timeout = timeout
+}
+
+// WithContext adds the context to the users owner groups create params
+func (o *UsersOwnerGroupsCreateParams) WithContext(ctx context.Context) *UsersOwnerGroupsCreateParams {
+	o.SetContext(ctx)
+	return o
+}
+
+// SetContext adds the context to the users owner groups create params
+func (o *UsersOwnerGroupsCreateParams) SetContext(ctx context.Context) {
+	o.Context = ctx
+}
+
+// WithHTTPClient adds the HTTPClient to the users owner groups create params
+func (o *UsersOwnerGroupsCreateParams) WithHTTPClient(client *http.Client) *UsersOwnerGroupsCreateParams {
+	o.SetHTTPClient(client)
+	return o
+}
+
+// SetHTTPClient adds the HTTPClient to the users owner groups create params
+func (o *UsersOwnerGroupsCreateParams) SetHTTPClient(client *http.Client) {
+	o.HTTPClient = client
+}
+
+// WithData adds the data to the users owner groups create params
+func (o *UsersOwnerGroupsCreateParams) WithData(data *models.OwnerGroup) *UsersOwnerGroupsCreateParams {
+	o.SetData(data)
+	return o
+}
+
+// SetData adds the data to the users owner groups create params
+func (o *UsersOwnerGroupsCreateParams) SetData(data *models.OwnerGroup) {
+	o.Data = data
+}
+
+// WriteToRequest writes these params to a swagger request
+func (o *UsersOwnerGroupsCreateParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.Registry) error {
+
+	if err := r.SetTimeout(o.timeout); err != nil {
+		return err
+	}
+	var res []error
+	if o.Data != nil {
+		if err := r.SetBodyParam(o.Data); err != nil {
+			return err
+		}
+	}
+
+	if len(res) > 0 {
+		return errors.CompositeValidationError(res...)
+	}
+	return nil
+}

--- a/netbox/client/users/users_owner_groups_create_responses.go
+++ b/netbox/client/users/users_owner_groups_create_responses.go
@@ -1,0 +1,199 @@
+// Copyright 2020 The go-netbox Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package users
+
+// This file was manually added to extend the client with NetBox's Owner/OwnerGroup
+// endpoints (netbox-community/netbox users app), which are not yet covered by the
+// upstream swagger-generated client.
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+
+	"github.com/go-openapi/runtime"
+	"github.com/go-openapi/strfmt"
+
+	"github.com/fbreckle/go-netbox/netbox/models"
+)
+
+// UsersOwnerGroupsCreateReader is a Reader for the UsersOwnerGroupsCreate structure.
+type UsersOwnerGroupsCreateReader struct {
+	formats strfmt.Registry
+}
+
+// ReadResponse reads a server response into the received o.
+func (o *UsersOwnerGroupsCreateReader) ReadResponse(response runtime.ClientResponse, consumer runtime.Consumer) (interface{}, error) {
+	switch response.Code() {
+	case 201:
+		result := NewUsersOwnerGroupsCreateCreated()
+		if err := result.readResponse(response, consumer, o.formats); err != nil {
+			return nil, err
+		}
+		return result, nil
+	default:
+		result := NewUsersOwnerGroupsCreateDefault(response.Code())
+		if err := result.readResponse(response, consumer, o.formats); err != nil {
+			return nil, err
+		}
+		if response.Code()/100 == 2 {
+			return result, nil
+		}
+		return nil, result
+	}
+}
+
+// NewUsersOwnerGroupsCreateCreated creates a UsersOwnerGroupsCreateCreated with default headers values
+func NewUsersOwnerGroupsCreateCreated() *UsersOwnerGroupsCreateCreated {
+	return &UsersOwnerGroupsCreateCreated{}
+}
+
+/*
+UsersOwnerGroupsCreateCreated describes a response with status code 201, with default header values.
+
+UsersOwnerGroupsCreateCreated users owner groups create created
+*/
+type UsersOwnerGroupsCreateCreated struct {
+	Payload *models.OwnerGroup
+}
+
+// IsSuccess returns true when this users owner groups create created response has a 2xx status code
+func (o *UsersOwnerGroupsCreateCreated) IsSuccess() bool {
+	return true
+}
+
+// IsRedirect returns true when this users owner groups create created response has a 3xx status code
+func (o *UsersOwnerGroupsCreateCreated) IsRedirect() bool {
+	return false
+}
+
+// IsClientError returns true when this users owner groups create created response has a 4xx status code
+func (o *UsersOwnerGroupsCreateCreated) IsClientError() bool {
+	return false
+}
+
+// IsServerError returns true when this users owner groups create created response has a 5xx status code
+func (o *UsersOwnerGroupsCreateCreated) IsServerError() bool {
+	return false
+}
+
+// IsCode returns true when this users owner groups create created response a status code equal to that given
+func (o *UsersOwnerGroupsCreateCreated) IsCode(code int) bool {
+	return code == 201
+}
+
+// Code gets the status code for the users owner groups create created response
+func (o *UsersOwnerGroupsCreateCreated) Code() int {
+	return 201
+}
+
+func (o *UsersOwnerGroupsCreateCreated) Error() string {
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /users/owner-groups/][%d] usersOwnerGroupsCreateCreated %s", 201, payload)
+}
+
+func (o *UsersOwnerGroupsCreateCreated) String() string {
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /users/owner-groups/][%d] usersOwnerGroupsCreateCreated %s", 201, payload)
+}
+
+func (o *UsersOwnerGroupsCreateCreated) GetPayload() *models.OwnerGroup {
+	return o.Payload
+}
+
+func (o *UsersOwnerGroupsCreateCreated) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
+
+	o.Payload = new(models.OwnerGroup)
+
+	// response payload
+	if err := consumer.Consume(response.Body(), o.Payload); err != nil && err != io.EOF {
+		return err
+	}
+
+	return nil
+}
+
+// NewUsersOwnerGroupsCreateDefault creates a UsersOwnerGroupsCreateDefault with default headers values
+func NewUsersOwnerGroupsCreateDefault(code int) *UsersOwnerGroupsCreateDefault {
+	return &UsersOwnerGroupsCreateDefault{
+		_statusCode: code,
+	}
+}
+
+/*
+UsersOwnerGroupsCreateDefault describes a response with status code -1, with default header values.
+
+UsersOwnerGroupsCreateDefault users owner groups create default
+*/
+type UsersOwnerGroupsCreateDefault struct {
+	_statusCode int
+
+	Payload interface{}
+}
+
+// IsSuccess returns true when this users owner groups create default response has a 2xx status code
+func (o *UsersOwnerGroupsCreateDefault) IsSuccess() bool {
+	return o._statusCode/100 == 2
+}
+
+// IsRedirect returns true when this users owner groups create default response has a 3xx status code
+func (o *UsersOwnerGroupsCreateDefault) IsRedirect() bool {
+	return o._statusCode/100 == 3
+}
+
+// IsClientError returns true when this users owner groups create default response has a 4xx status code
+func (o *UsersOwnerGroupsCreateDefault) IsClientError() bool {
+	return o._statusCode/100 == 4
+}
+
+// IsServerError returns true when this users owner groups create default response has a 5xx status code
+func (o *UsersOwnerGroupsCreateDefault) IsServerError() bool {
+	return o._statusCode/100 == 5
+}
+
+// IsCode returns true when this users owner groups create default response a status code equal to that given
+func (o *UsersOwnerGroupsCreateDefault) IsCode(code int) bool {
+	return o._statusCode == code
+}
+
+// Code gets the status code for the users owner groups create default response
+func (o *UsersOwnerGroupsCreateDefault) Code() int {
+	return o._statusCode
+}
+
+func (o *UsersOwnerGroupsCreateDefault) Error() string {
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /users/owner-groups/][%d] users_owner_groups_create default %s", o._statusCode, payload)
+}
+
+func (o *UsersOwnerGroupsCreateDefault) String() string {
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /users/owner-groups/][%d] users_owner_groups_create default %s", o._statusCode, payload)
+}
+
+func (o *UsersOwnerGroupsCreateDefault) GetPayload() interface{} {
+	return o.Payload
+}
+
+func (o *UsersOwnerGroupsCreateDefault) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
+
+	// response payload
+	if err := consumer.Consume(response.Body(), &o.Payload); err != nil && err != io.EOF {
+		return err
+	}
+
+	return nil
+}

--- a/netbox/client/users/users_owner_groups_delete_parameters.go
+++ b/netbox/client/users/users_owner_groups_delete_parameters.go
@@ -1,0 +1,166 @@
+// Copyright 2020 The go-netbox Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package users
+
+// This file was manually added to extend the client with NetBox's Owner/OwnerGroup
+// endpoints (netbox-community/netbox users app), which are not yet covered by the
+// upstream swagger-generated client.
+
+import (
+	"context"
+	"net/http"
+	"time"
+
+	"github.com/go-openapi/errors"
+	"github.com/go-openapi/runtime"
+	cr "github.com/go-openapi/runtime/client"
+	"github.com/go-openapi/strfmt"
+	"github.com/go-openapi/swag"
+)
+
+// NewUsersOwnerGroupsDeleteParams creates a new UsersOwnerGroupsDeleteParams object,
+// with the default timeout for this client.
+//
+// Default values are not hydrated, since defaults are normally applied by the API server side.
+//
+// To enforce default values in parameter, use SetDefaults or WithDefaults.
+func NewUsersOwnerGroupsDeleteParams() *UsersOwnerGroupsDeleteParams {
+	return &UsersOwnerGroupsDeleteParams{
+		timeout: cr.DefaultTimeout,
+	}
+}
+
+// NewUsersOwnerGroupsDeleteParamsWithTimeout creates a new UsersOwnerGroupsDeleteParams object
+// with the ability to set a timeout on a request.
+func NewUsersOwnerGroupsDeleteParamsWithTimeout(timeout time.Duration) *UsersOwnerGroupsDeleteParams {
+	return &UsersOwnerGroupsDeleteParams{
+		timeout: timeout,
+	}
+}
+
+// NewUsersOwnerGroupsDeleteParamsWithContext creates a new UsersOwnerGroupsDeleteParams object
+// with the ability to set a context for a request.
+func NewUsersOwnerGroupsDeleteParamsWithContext(ctx context.Context) *UsersOwnerGroupsDeleteParams {
+	return &UsersOwnerGroupsDeleteParams{
+		Context: ctx,
+	}
+}
+
+// NewUsersOwnerGroupsDeleteParamsWithHTTPClient creates a new UsersOwnerGroupsDeleteParams object
+// with the ability to set a custom HTTPClient for a request.
+func NewUsersOwnerGroupsDeleteParamsWithHTTPClient(client *http.Client) *UsersOwnerGroupsDeleteParams {
+	return &UsersOwnerGroupsDeleteParams{
+		HTTPClient: client,
+	}
+}
+
+/*
+UsersOwnerGroupsDeleteParams contains all the parameters to send to the API endpoint
+
+	for the users owner groups delete operation.
+
+	Typically these are written to a http.Request.
+*/
+type UsersOwnerGroupsDeleteParams struct {
+
+	/* ID.
+
+	   A unique integer value identifying this owner group.
+	*/
+	ID int64
+
+	timeout    time.Duration
+	Context    context.Context
+	HTTPClient *http.Client
+}
+
+// WithDefaults hydrates default values in the users owner groups delete params (not the query body).
+//
+// All values with no default are reset to their zero value.
+func (o *UsersOwnerGroupsDeleteParams) WithDefaults() *UsersOwnerGroupsDeleteParams {
+	o.SetDefaults()
+	return o
+}
+
+// SetDefaults hydrates default values in the users owner groups delete params (not the query body).
+//
+// All values with no default are reset to their zero value.
+func (o *UsersOwnerGroupsDeleteParams) SetDefaults() {
+	// no default values defined for this parameter
+}
+
+// WithTimeout adds the timeout to the users owner groups delete params
+func (o *UsersOwnerGroupsDeleteParams) WithTimeout(timeout time.Duration) *UsersOwnerGroupsDeleteParams {
+	o.SetTimeout(timeout)
+	return o
+}
+
+// SetTimeout adds the timeout to the users owner groups delete params
+func (o *UsersOwnerGroupsDeleteParams) SetTimeout(timeout time.Duration) {
+	o.timeout = timeout
+}
+
+// WithContext adds the context to the users owner groups delete params
+func (o *UsersOwnerGroupsDeleteParams) WithContext(ctx context.Context) *UsersOwnerGroupsDeleteParams {
+	o.SetContext(ctx)
+	return o
+}
+
+// SetContext adds the context to the users owner groups delete params
+func (o *UsersOwnerGroupsDeleteParams) SetContext(ctx context.Context) {
+	o.Context = ctx
+}
+
+// WithHTTPClient adds the HTTPClient to the users owner groups delete params
+func (o *UsersOwnerGroupsDeleteParams) WithHTTPClient(client *http.Client) *UsersOwnerGroupsDeleteParams {
+	o.SetHTTPClient(client)
+	return o
+}
+
+// SetHTTPClient adds the HTTPClient to the users owner groups delete params
+func (o *UsersOwnerGroupsDeleteParams) SetHTTPClient(client *http.Client) {
+	o.HTTPClient = client
+}
+
+// WithID adds the id to the users owner groups delete params
+func (o *UsersOwnerGroupsDeleteParams) WithID(id int64) *UsersOwnerGroupsDeleteParams {
+	o.SetID(id)
+	return o
+}
+
+// SetID adds the id to the users owner groups delete params
+func (o *UsersOwnerGroupsDeleteParams) SetID(id int64) {
+	o.ID = id
+}
+
+// WriteToRequest writes these params to a swagger request
+func (o *UsersOwnerGroupsDeleteParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.Registry) error {
+
+	if err := r.SetTimeout(o.timeout); err != nil {
+		return err
+	}
+	var res []error
+
+	// path param id
+	if err := r.SetPathParam("id", swag.FormatInt64(o.ID)); err != nil {
+		return err
+	}
+
+	if len(res) > 0 {
+		return errors.CompositeValidationError(res...)
+	}
+	return nil
+}

--- a/netbox/client/users/users_owner_groups_delete_responses.go
+++ b/netbox/client/users/users_owner_groups_delete_responses.go
@@ -1,0 +1,183 @@
+// Copyright 2020 The go-netbox Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package users
+
+// This file was manually added to extend the client with NetBox's Owner/OwnerGroup
+// endpoints (netbox-community/netbox users app), which are not yet covered by the
+// upstream swagger-generated client.
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+
+	"github.com/go-openapi/runtime"
+	"github.com/go-openapi/strfmt"
+)
+
+// UsersOwnerGroupsDeleteReader is a Reader for the UsersOwnerGroupsDelete structure.
+type UsersOwnerGroupsDeleteReader struct {
+	formats strfmt.Registry
+}
+
+// ReadResponse reads a server response into the received o.
+func (o *UsersOwnerGroupsDeleteReader) ReadResponse(response runtime.ClientResponse, consumer runtime.Consumer) (interface{}, error) {
+	switch response.Code() {
+	case 204:
+		result := NewUsersOwnerGroupsDeleteNoContent()
+		if err := result.readResponse(response, consumer, o.formats); err != nil {
+			return nil, err
+		}
+		return result, nil
+	default:
+		result := NewUsersOwnerGroupsDeleteDefault(response.Code())
+		if err := result.readResponse(response, consumer, o.formats); err != nil {
+			return nil, err
+		}
+		if response.Code()/100 == 2 {
+			return result, nil
+		}
+		return nil, result
+	}
+}
+
+// NewUsersOwnerGroupsDeleteNoContent creates a UsersOwnerGroupsDeleteNoContent with default headers values
+func NewUsersOwnerGroupsDeleteNoContent() *UsersOwnerGroupsDeleteNoContent {
+	return &UsersOwnerGroupsDeleteNoContent{}
+}
+
+/*
+UsersOwnerGroupsDeleteNoContent describes a response with status code 204, with default header values.
+
+UsersOwnerGroupsDeleteNoContent users owner groups delete no content
+*/
+type UsersOwnerGroupsDeleteNoContent struct {
+}
+
+// IsSuccess returns true when this users owner groups delete no content response has a 2xx status code
+func (o *UsersOwnerGroupsDeleteNoContent) IsSuccess() bool {
+	return true
+}
+
+// IsRedirect returns true when this users owner groups delete no content response has a 3xx status code
+func (o *UsersOwnerGroupsDeleteNoContent) IsRedirect() bool {
+	return false
+}
+
+// IsClientError returns true when this users owner groups delete no content response has a 4xx status code
+func (o *UsersOwnerGroupsDeleteNoContent) IsClientError() bool {
+	return false
+}
+
+// IsServerError returns true when this users owner groups delete no content response has a 5xx status code
+func (o *UsersOwnerGroupsDeleteNoContent) IsServerError() bool {
+	return false
+}
+
+// IsCode returns true when this users owner groups delete no content response a status code equal to that given
+func (o *UsersOwnerGroupsDeleteNoContent) IsCode(code int) bool {
+	return code == 204
+}
+
+// Code gets the status code for the users owner groups delete no content response
+func (o *UsersOwnerGroupsDeleteNoContent) Code() int {
+	return 204
+}
+
+func (o *UsersOwnerGroupsDeleteNoContent) Error() string {
+	return fmt.Sprintf("[DELETE /users/owner-groups/{id}/][%d] usersOwnerGroupsDeleteNoContent", 204)
+}
+
+func (o *UsersOwnerGroupsDeleteNoContent) String() string {
+	return fmt.Sprintf("[DELETE /users/owner-groups/{id}/][%d] usersOwnerGroupsDeleteNoContent", 204)
+}
+
+func (o *UsersOwnerGroupsDeleteNoContent) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
+
+	return nil
+}
+
+// NewUsersOwnerGroupsDeleteDefault creates a UsersOwnerGroupsDeleteDefault with default headers values
+func NewUsersOwnerGroupsDeleteDefault(code int) *UsersOwnerGroupsDeleteDefault {
+	return &UsersOwnerGroupsDeleteDefault{
+		_statusCode: code,
+	}
+}
+
+/*
+UsersOwnerGroupsDeleteDefault describes a response with status code -1, with default header values.
+
+UsersOwnerGroupsDeleteDefault users owner groups delete default
+*/
+type UsersOwnerGroupsDeleteDefault struct {
+	_statusCode int
+
+	Payload interface{}
+}
+
+// IsSuccess returns true when this users owner groups delete default response has a 2xx status code
+func (o *UsersOwnerGroupsDeleteDefault) IsSuccess() bool {
+	return o._statusCode/100 == 2
+}
+
+// IsRedirect returns true when this users owner groups delete default response has a 3xx status code
+func (o *UsersOwnerGroupsDeleteDefault) IsRedirect() bool {
+	return o._statusCode/100 == 3
+}
+
+// IsClientError returns true when this users owner groups delete default response has a 4xx status code
+func (o *UsersOwnerGroupsDeleteDefault) IsClientError() bool {
+	return o._statusCode/100 == 4
+}
+
+// IsServerError returns true when this users owner groups delete default response has a 5xx status code
+func (o *UsersOwnerGroupsDeleteDefault) IsServerError() bool {
+	return o._statusCode/100 == 5
+}
+
+// IsCode returns true when this users owner groups delete default response a status code equal to that given
+func (o *UsersOwnerGroupsDeleteDefault) IsCode(code int) bool {
+	return o._statusCode == code
+}
+
+// Code gets the status code for the users owner groups delete default response
+func (o *UsersOwnerGroupsDeleteDefault) Code() int {
+	return o._statusCode
+}
+
+func (o *UsersOwnerGroupsDeleteDefault) Error() string {
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[DELETE /users/owner-groups/{id}/][%d] users_owner_groups_delete default %s", o._statusCode, payload)
+}
+
+func (o *UsersOwnerGroupsDeleteDefault) String() string {
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[DELETE /users/owner-groups/{id}/][%d] users_owner_groups_delete default %s", o._statusCode, payload)
+}
+
+func (o *UsersOwnerGroupsDeleteDefault) GetPayload() interface{} {
+	return o.Payload
+}
+
+func (o *UsersOwnerGroupsDeleteDefault) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
+
+	// response payload
+	if err := consumer.Consume(response.Body(), &o.Payload); err != nil && err != io.EOF {
+		return err
+	}
+
+	return nil
+}

--- a/netbox/client/users/users_owner_groups_list_parameters.go
+++ b/netbox/client/users/users_owner_groups_list_parameters.go
@@ -1,0 +1,795 @@
+// Copyright 2020 The go-netbox Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package users
+
+// This file was manually added to extend the client with NetBox's Owner/OwnerGroup
+// endpoints (netbox-community/netbox users app), which are not yet covered by the
+// upstream swagger-generated client.
+
+import (
+	"context"
+	"net/http"
+	"time"
+
+	"github.com/go-openapi/errors"
+	"github.com/go-openapi/runtime"
+	cr "github.com/go-openapi/runtime/client"
+	"github.com/go-openapi/strfmt"
+	"github.com/go-openapi/swag"
+)
+
+// NewUsersOwnerGroupsListParams creates a new UsersOwnerGroupsListParams object,
+// with the default timeout for this client.
+//
+// Default values are not hydrated, since defaults are normally applied by the API server side.
+//
+// To enforce default values in parameter, use SetDefaults or WithDefaults.
+func NewUsersOwnerGroupsListParams() *UsersOwnerGroupsListParams {
+	return &UsersOwnerGroupsListParams{
+		timeout: cr.DefaultTimeout,
+	}
+}
+
+// NewUsersOwnerGroupsListParamsWithTimeout creates a new UsersOwnerGroupsListParams object
+// with the ability to set a timeout on a request.
+func NewUsersOwnerGroupsListParamsWithTimeout(timeout time.Duration) *UsersOwnerGroupsListParams {
+	return &UsersOwnerGroupsListParams{
+		timeout: timeout,
+	}
+}
+
+// NewUsersOwnerGroupsListParamsWithContext creates a new UsersOwnerGroupsListParams object
+// with the ability to set a context for a request.
+func NewUsersOwnerGroupsListParamsWithContext(ctx context.Context) *UsersOwnerGroupsListParams {
+	return &UsersOwnerGroupsListParams{
+		Context: ctx,
+	}
+}
+
+// NewUsersOwnerGroupsListParamsWithHTTPClient creates a new UsersOwnerGroupsListParams object
+// with the ability to set a custom HTTPClient for a request.
+func NewUsersOwnerGroupsListParamsWithHTTPClient(client *http.Client) *UsersOwnerGroupsListParams {
+	return &UsersOwnerGroupsListParams{
+		HTTPClient: client,
+	}
+}
+
+/*
+UsersOwnerGroupsListParams contains all the parameters to send to the API endpoint
+
+	for the users owner groups list operation.
+
+	Typically these are written to a http.Request.
+*/
+type UsersOwnerGroupsListParams struct {
+
+	// ID.
+	ID *string
+
+	// IDGt.
+	IDGt *string
+
+	// IDGte.
+	IDGte *string
+
+	// IDLt.
+	IDLt *string
+
+	// IDLte.
+	IDLte *string
+
+	// IDn.
+	IDn *string
+
+	// Limit.
+	Limit *int64
+
+	// Name.
+	Name *string
+
+	// NameEmpty.
+	NameEmpty *string
+
+	// NameIc.
+	NameIc *string
+
+	// NameIe.
+	NameIe *string
+
+	// NameIew.
+	NameIew *string
+
+	// NameIsw.
+	NameIsw *string
+
+	// Namen.
+	Namen *string
+
+	// NameNic.
+	NameNic *string
+
+	// NameNie.
+	NameNie *string
+
+	// NameNiew.
+	NameNiew *string
+
+	// NameNisw.
+	NameNisw *string
+
+	// Offset.
+	Offset *int64
+
+	// Ordering.
+	Ordering *string
+
+	// Q.
+	Q *string
+
+	timeout    time.Duration
+	Context    context.Context
+	HTTPClient *http.Client
+}
+
+// WithDefaults hydrates default values in the users owner groups list params (not the query body).
+//
+// All values with no default are reset to their zero value.
+func (o *UsersOwnerGroupsListParams) WithDefaults() *UsersOwnerGroupsListParams {
+	o.SetDefaults()
+	return o
+}
+
+// SetDefaults hydrates default values in the users owner groups list params (not the query body).
+//
+// All values with no default are reset to their zero value.
+func (o *UsersOwnerGroupsListParams) SetDefaults() {
+	// no default values defined for this parameter
+}
+
+// WithTimeout adds the timeout to the users owner groups list params
+func (o *UsersOwnerGroupsListParams) WithTimeout(timeout time.Duration) *UsersOwnerGroupsListParams {
+	o.SetTimeout(timeout)
+	return o
+}
+
+// SetTimeout adds the timeout to the users owner groups list params
+func (o *UsersOwnerGroupsListParams) SetTimeout(timeout time.Duration) {
+	o.timeout = timeout
+}
+
+// WithContext adds the context to the users owner groups list params
+func (o *UsersOwnerGroupsListParams) WithContext(ctx context.Context) *UsersOwnerGroupsListParams {
+	o.SetContext(ctx)
+	return o
+}
+
+// SetContext adds the context to the users owner groups list params
+func (o *UsersOwnerGroupsListParams) SetContext(ctx context.Context) {
+	o.Context = ctx
+}
+
+// WithHTTPClient adds the HTTPClient to the users owner groups list params
+func (o *UsersOwnerGroupsListParams) WithHTTPClient(client *http.Client) *UsersOwnerGroupsListParams {
+	o.SetHTTPClient(client)
+	return o
+}
+
+// SetHTTPClient adds the HTTPClient to the users owner groups list params
+func (o *UsersOwnerGroupsListParams) SetHTTPClient(client *http.Client) {
+	o.HTTPClient = client
+}
+
+// WithID adds the iD to the users owner groups list params
+func (o *UsersOwnerGroupsListParams) WithID(iD *string) *UsersOwnerGroupsListParams {
+	o.SetID(iD)
+	return o
+}
+
+// SetID adds the iD to the users owner groups list params
+func (o *UsersOwnerGroupsListParams) SetID(iD *string) {
+	o.ID = iD
+}
+
+// WithIDGt adds the iDGt to the users owner groups list params
+func (o *UsersOwnerGroupsListParams) WithIDGt(iDGt *string) *UsersOwnerGroupsListParams {
+	o.SetIDGt(iDGt)
+	return o
+}
+
+// SetIDGt adds the iDGt to the users owner groups list params
+func (o *UsersOwnerGroupsListParams) SetIDGt(iDGt *string) {
+	o.IDGt = iDGt
+}
+
+// WithIDGte adds the iDGte to the users owner groups list params
+func (o *UsersOwnerGroupsListParams) WithIDGte(iDGte *string) *UsersOwnerGroupsListParams {
+	o.SetIDGte(iDGte)
+	return o
+}
+
+// SetIDGte adds the iDGte to the users owner groups list params
+func (o *UsersOwnerGroupsListParams) SetIDGte(iDGte *string) {
+	o.IDGte = iDGte
+}
+
+// WithIDLt adds the iDLt to the users owner groups list params
+func (o *UsersOwnerGroupsListParams) WithIDLt(iDLt *string) *UsersOwnerGroupsListParams {
+	o.SetIDLt(iDLt)
+	return o
+}
+
+// SetIDLt adds the iDLt to the users owner groups list params
+func (o *UsersOwnerGroupsListParams) SetIDLt(iDLt *string) {
+	o.IDLt = iDLt
+}
+
+// WithIDLte adds the iDLte to the users owner groups list params
+func (o *UsersOwnerGroupsListParams) WithIDLte(iDLte *string) *UsersOwnerGroupsListParams {
+	o.SetIDLte(iDLte)
+	return o
+}
+
+// SetIDLte adds the iDLte to the users owner groups list params
+func (o *UsersOwnerGroupsListParams) SetIDLte(iDLte *string) {
+	o.IDLte = iDLte
+}
+
+// WithIDn adds the iDn to the users owner groups list params
+func (o *UsersOwnerGroupsListParams) WithIDn(iDn *string) *UsersOwnerGroupsListParams {
+	o.SetIDn(iDn)
+	return o
+}
+
+// SetIDn adds the iDn to the users owner groups list params
+func (o *UsersOwnerGroupsListParams) SetIDn(iDn *string) {
+	o.IDn = iDn
+}
+
+// WithLimit adds the limit to the users owner groups list params
+func (o *UsersOwnerGroupsListParams) WithLimit(limit *int64) *UsersOwnerGroupsListParams {
+	o.SetLimit(limit)
+	return o
+}
+
+// SetLimit adds the limit to the users owner groups list params
+func (o *UsersOwnerGroupsListParams) SetLimit(limit *int64) {
+	o.Limit = limit
+}
+
+// WithName adds the name to the users owner groups list params
+func (o *UsersOwnerGroupsListParams) WithName(name *string) *UsersOwnerGroupsListParams {
+	o.SetName(name)
+	return o
+}
+
+// SetName adds the name to the users owner groups list params
+func (o *UsersOwnerGroupsListParams) SetName(name *string) {
+	o.Name = name
+}
+
+// WithNameEmpty adds the nameEmpty to the users owner groups list params
+func (o *UsersOwnerGroupsListParams) WithNameEmpty(nameEmpty *string) *UsersOwnerGroupsListParams {
+	o.SetNameEmpty(nameEmpty)
+	return o
+}
+
+// SetNameEmpty adds the nameEmpty to the users owner groups list params
+func (o *UsersOwnerGroupsListParams) SetNameEmpty(nameEmpty *string) {
+	o.NameEmpty = nameEmpty
+}
+
+// WithNameIc adds the nameIc to the users owner groups list params
+func (o *UsersOwnerGroupsListParams) WithNameIc(nameIc *string) *UsersOwnerGroupsListParams {
+	o.SetNameIc(nameIc)
+	return o
+}
+
+// SetNameIc adds the nameIc to the users owner groups list params
+func (o *UsersOwnerGroupsListParams) SetNameIc(nameIc *string) {
+	o.NameIc = nameIc
+}
+
+// WithNameIe adds the nameIe to the users owner groups list params
+func (o *UsersOwnerGroupsListParams) WithNameIe(nameIe *string) *UsersOwnerGroupsListParams {
+	o.SetNameIe(nameIe)
+	return o
+}
+
+// SetNameIe adds the nameIe to the users owner groups list params
+func (o *UsersOwnerGroupsListParams) SetNameIe(nameIe *string) {
+	o.NameIe = nameIe
+}
+
+// WithNameIew adds the nameIew to the users owner groups list params
+func (o *UsersOwnerGroupsListParams) WithNameIew(nameIew *string) *UsersOwnerGroupsListParams {
+	o.SetNameIew(nameIew)
+	return o
+}
+
+// SetNameIew adds the nameIew to the users owner groups list params
+func (o *UsersOwnerGroupsListParams) SetNameIew(nameIew *string) {
+	o.NameIew = nameIew
+}
+
+// WithNameIsw adds the nameIsw to the users owner groups list params
+func (o *UsersOwnerGroupsListParams) WithNameIsw(nameIsw *string) *UsersOwnerGroupsListParams {
+	o.SetNameIsw(nameIsw)
+	return o
+}
+
+// SetNameIsw adds the nameIsw to the users owner groups list params
+func (o *UsersOwnerGroupsListParams) SetNameIsw(nameIsw *string) {
+	o.NameIsw = nameIsw
+}
+
+// WithNamen adds the namen to the users owner groups list params
+func (o *UsersOwnerGroupsListParams) WithNamen(namen *string) *UsersOwnerGroupsListParams {
+	o.SetNamen(namen)
+	return o
+}
+
+// SetNamen adds the namen to the users owner groups list params
+func (o *UsersOwnerGroupsListParams) SetNamen(namen *string) {
+	o.Namen = namen
+}
+
+// WithNameNic adds the nameNic to the users owner groups list params
+func (o *UsersOwnerGroupsListParams) WithNameNic(nameNic *string) *UsersOwnerGroupsListParams {
+	o.SetNameNic(nameNic)
+	return o
+}
+
+// SetNameNic adds the nameNic to the users owner groups list params
+func (o *UsersOwnerGroupsListParams) SetNameNic(nameNic *string) {
+	o.NameNic = nameNic
+}
+
+// WithNameNie adds the nameNie to the users owner groups list params
+func (o *UsersOwnerGroupsListParams) WithNameNie(nameNie *string) *UsersOwnerGroupsListParams {
+	o.SetNameNie(nameNie)
+	return o
+}
+
+// SetNameNie adds the nameNie to the users owner groups list params
+func (o *UsersOwnerGroupsListParams) SetNameNie(nameNie *string) {
+	o.NameNie = nameNie
+}
+
+// WithNameNiew adds the nameNiew to the users owner groups list params
+func (o *UsersOwnerGroupsListParams) WithNameNiew(nameNiew *string) *UsersOwnerGroupsListParams {
+	o.SetNameNiew(nameNiew)
+	return o
+}
+
+// SetNameNiew adds the nameNiew to the users owner groups list params
+func (o *UsersOwnerGroupsListParams) SetNameNiew(nameNiew *string) {
+	o.NameNiew = nameNiew
+}
+
+// WithNameNisw adds the nameNisw to the users owner groups list params
+func (o *UsersOwnerGroupsListParams) WithNameNisw(nameNisw *string) *UsersOwnerGroupsListParams {
+	o.SetNameNisw(nameNisw)
+	return o
+}
+
+// SetNameNisw adds the nameNisw to the users owner groups list params
+func (o *UsersOwnerGroupsListParams) SetNameNisw(nameNisw *string) {
+	o.NameNisw = nameNisw
+}
+
+// WithOffset adds the offset to the users owner groups list params
+func (o *UsersOwnerGroupsListParams) WithOffset(offset *int64) *UsersOwnerGroupsListParams {
+	o.SetOffset(offset)
+	return o
+}
+
+// SetOffset adds the offset to the users owner groups list params
+func (o *UsersOwnerGroupsListParams) SetOffset(offset *int64) {
+	o.Offset = offset
+}
+
+// WithOrdering adds the ordering to the users owner groups list params
+func (o *UsersOwnerGroupsListParams) WithOrdering(ordering *string) *UsersOwnerGroupsListParams {
+	o.SetOrdering(ordering)
+	return o
+}
+
+// SetOrdering adds the ordering to the users owner groups list params
+func (o *UsersOwnerGroupsListParams) SetOrdering(ordering *string) {
+	o.Ordering = ordering
+}
+
+// WithQ adds the q to the users owner groups list params
+func (o *UsersOwnerGroupsListParams) WithQ(q *string) *UsersOwnerGroupsListParams {
+	o.SetQ(q)
+	return o
+}
+
+// SetQ adds the q to the users owner groups list params
+func (o *UsersOwnerGroupsListParams) SetQ(q *string) {
+	o.Q = q
+}
+
+// WriteToRequest writes these params to a swagger request
+func (o *UsersOwnerGroupsListParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.Registry) error {
+
+	if err := r.SetTimeout(o.timeout); err != nil {
+		return err
+	}
+	var res []error
+
+	if o.ID != nil {
+
+		// query param id
+		var qrID string
+
+		if o.ID != nil {
+			qrID = *o.ID
+		}
+		qID := qrID
+		if qID != "" {
+
+			if err := r.SetQueryParam("id", qID); err != nil {
+				return err
+			}
+		}
+	}
+
+	if o.IDGt != nil {
+
+		// query param id__gt
+		var qrIDGt string
+
+		if o.IDGt != nil {
+			qrIDGt = *o.IDGt
+		}
+		qIDGt := qrIDGt
+		if qIDGt != "" {
+
+			if err := r.SetQueryParam("id__gt", qIDGt); err != nil {
+				return err
+			}
+		}
+	}
+
+	if o.IDGte != nil {
+
+		// query param id__gte
+		var qrIDGte string
+
+		if o.IDGte != nil {
+			qrIDGte = *o.IDGte
+		}
+		qIDGte := qrIDGte
+		if qIDGte != "" {
+
+			if err := r.SetQueryParam("id__gte", qIDGte); err != nil {
+				return err
+			}
+		}
+	}
+
+	if o.IDLt != nil {
+
+		// query param id__lt
+		var qrIDLt string
+
+		if o.IDLt != nil {
+			qrIDLt = *o.IDLt
+		}
+		qIDLt := qrIDLt
+		if qIDLt != "" {
+
+			if err := r.SetQueryParam("id__lt", qIDLt); err != nil {
+				return err
+			}
+		}
+	}
+
+	if o.IDLte != nil {
+
+		// query param id__lte
+		var qrIDLte string
+
+		if o.IDLte != nil {
+			qrIDLte = *o.IDLte
+		}
+		qIDLte := qrIDLte
+		if qIDLte != "" {
+
+			if err := r.SetQueryParam("id__lte", qIDLte); err != nil {
+				return err
+			}
+		}
+	}
+
+	if o.IDn != nil {
+
+		// query param id__n
+		var qrIDn string
+
+		if o.IDn != nil {
+			qrIDn = *o.IDn
+		}
+		qIDn := qrIDn
+		if qIDn != "" {
+
+			if err := r.SetQueryParam("id__n", qIDn); err != nil {
+				return err
+			}
+		}
+	}
+
+	if o.Limit != nil {
+
+		// query param limit
+		var qrLimit int64
+
+		if o.Limit != nil {
+			qrLimit = *o.Limit
+		}
+		qLimit := swag.FormatInt64(qrLimit)
+		if qLimit != "" {
+
+			if err := r.SetQueryParam("limit", qLimit); err != nil {
+				return err
+			}
+		}
+	}
+
+	if o.Name != nil {
+
+		// query param name
+		var qrName string
+
+		if o.Name != nil {
+			qrName = *o.Name
+		}
+		qName := qrName
+		if qName != "" {
+
+			if err := r.SetQueryParam("name", qName); err != nil {
+				return err
+			}
+		}
+	}
+
+	if o.NameEmpty != nil {
+
+		// query param name__empty
+		var qrNameEmpty string
+
+		if o.NameEmpty != nil {
+			qrNameEmpty = *o.NameEmpty
+		}
+		qNameEmpty := qrNameEmpty
+		if qNameEmpty != "" {
+
+			if err := r.SetQueryParam("name__empty", qNameEmpty); err != nil {
+				return err
+			}
+		}
+	}
+
+	if o.NameIc != nil {
+
+		// query param name__ic
+		var qrNameIc string
+
+		if o.NameIc != nil {
+			qrNameIc = *o.NameIc
+		}
+		qNameIc := qrNameIc
+		if qNameIc != "" {
+
+			if err := r.SetQueryParam("name__ic", qNameIc); err != nil {
+				return err
+			}
+		}
+	}
+
+	if o.NameIe != nil {
+
+		// query param name__ie
+		var qrNameIe string
+
+		if o.NameIe != nil {
+			qrNameIe = *o.NameIe
+		}
+		qNameIe := qrNameIe
+		if qNameIe != "" {
+
+			if err := r.SetQueryParam("name__ie", qNameIe); err != nil {
+				return err
+			}
+		}
+	}
+
+	if o.NameIew != nil {
+
+		// query param name__iew
+		var qrNameIew string
+
+		if o.NameIew != nil {
+			qrNameIew = *o.NameIew
+		}
+		qNameIew := qrNameIew
+		if qNameIew != "" {
+
+			if err := r.SetQueryParam("name__iew", qNameIew); err != nil {
+				return err
+			}
+		}
+	}
+
+	if o.NameIsw != nil {
+
+		// query param name__isw
+		var qrNameIsw string
+
+		if o.NameIsw != nil {
+			qrNameIsw = *o.NameIsw
+		}
+		qNameIsw := qrNameIsw
+		if qNameIsw != "" {
+
+			if err := r.SetQueryParam("name__isw", qNameIsw); err != nil {
+				return err
+			}
+		}
+	}
+
+	if o.Namen != nil {
+
+		// query param name__n
+		var qrNamen string
+
+		if o.Namen != nil {
+			qrNamen = *o.Namen
+		}
+		qNamen := qrNamen
+		if qNamen != "" {
+
+			if err := r.SetQueryParam("name__n", qNamen); err != nil {
+				return err
+			}
+		}
+	}
+
+	if o.NameNic != nil {
+
+		// query param name__nic
+		var qrNameNic string
+
+		if o.NameNic != nil {
+			qrNameNic = *o.NameNic
+		}
+		qNameNic := qrNameNic
+		if qNameNic != "" {
+
+			if err := r.SetQueryParam("name__nic", qNameNic); err != nil {
+				return err
+			}
+		}
+	}
+
+	if o.NameNie != nil {
+
+		// query param name__nie
+		var qrNameNie string
+
+		if o.NameNie != nil {
+			qrNameNie = *o.NameNie
+		}
+		qNameNie := qrNameNie
+		if qNameNie != "" {
+
+			if err := r.SetQueryParam("name__nie", qNameNie); err != nil {
+				return err
+			}
+		}
+	}
+
+	if o.NameNiew != nil {
+
+		// query param name__niew
+		var qrNameNiew string
+
+		if o.NameNiew != nil {
+			qrNameNiew = *o.NameNiew
+		}
+		qNameNiew := qrNameNiew
+		if qNameNiew != "" {
+
+			if err := r.SetQueryParam("name__niew", qNameNiew); err != nil {
+				return err
+			}
+		}
+	}
+
+	if o.NameNisw != nil {
+
+		// query param name__nisw
+		var qrNameNisw string
+
+		if o.NameNisw != nil {
+			qrNameNisw = *o.NameNisw
+		}
+		qNameNisw := qrNameNisw
+		if qNameNisw != "" {
+
+			if err := r.SetQueryParam("name__nisw", qNameNisw); err != nil {
+				return err
+			}
+		}
+	}
+
+	if o.Offset != nil {
+
+		// query param offset
+		var qrOffset int64
+
+		if o.Offset != nil {
+			qrOffset = *o.Offset
+		}
+		qOffset := swag.FormatInt64(qrOffset)
+		if qOffset != "" {
+
+			if err := r.SetQueryParam("offset", qOffset); err != nil {
+				return err
+			}
+		}
+	}
+
+	if o.Ordering != nil {
+
+		// query param ordering
+		var qrOrdering string
+
+		if o.Ordering != nil {
+			qrOrdering = *o.Ordering
+		}
+		qOrdering := qrOrdering
+		if qOrdering != "" {
+
+			if err := r.SetQueryParam("ordering", qOrdering); err != nil {
+				return err
+			}
+		}
+	}
+
+	if o.Q != nil {
+
+		// query param q
+		var qrQ string
+
+		if o.Q != nil {
+			qrQ = *o.Q
+		}
+		qQ := qrQ
+		if qQ != "" {
+
+			if err := r.SetQueryParam("q", qQ); err != nil {
+				return err
+			}
+		}
+	}
+
+	if len(res) > 0 {
+		return errors.CompositeValidationError(res...)
+	}
+	return nil
+}

--- a/netbox/client/users/users_owner_groups_list_responses.go
+++ b/netbox/client/users/users_owner_groups_list_responses.go
@@ -1,0 +1,370 @@
+// Copyright 2020 The go-netbox Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package users
+
+// This file was manually added to extend the client with NetBox's Owner/OwnerGroup
+// endpoints (netbox-community/netbox users app), which are not yet covered by the
+// upstream swagger-generated client.
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"strconv"
+
+	"github.com/go-openapi/errors"
+	"github.com/go-openapi/runtime"
+	"github.com/go-openapi/strfmt"
+	"github.com/go-openapi/swag"
+	"github.com/go-openapi/validate"
+
+	"github.com/fbreckle/go-netbox/netbox/models"
+)
+
+// UsersOwnerGroupsListReader is a Reader for the UsersOwnerGroupsList structure.
+type UsersOwnerGroupsListReader struct {
+	formats strfmt.Registry
+}
+
+// ReadResponse reads a server response into the received o.
+func (o *UsersOwnerGroupsListReader) ReadResponse(response runtime.ClientResponse, consumer runtime.Consumer) (interface{}, error) {
+	switch response.Code() {
+	case 200:
+		result := NewUsersOwnerGroupsListOK()
+		if err := result.readResponse(response, consumer, o.formats); err != nil {
+			return nil, err
+		}
+		return result, nil
+	default:
+		result := NewUsersOwnerGroupsListDefault(response.Code())
+		if err := result.readResponse(response, consumer, o.formats); err != nil {
+			return nil, err
+		}
+		if response.Code()/100 == 2 {
+			return result, nil
+		}
+		return nil, result
+	}
+}
+
+// NewUsersOwnerGroupsListOK creates a UsersOwnerGroupsListOK with default headers values
+func NewUsersOwnerGroupsListOK() *UsersOwnerGroupsListOK {
+	return &UsersOwnerGroupsListOK{}
+}
+
+/*
+UsersOwnerGroupsListOK describes a response with status code 200, with default header values.
+
+UsersOwnerGroupsListOK users owner groups list o k
+*/
+type UsersOwnerGroupsListOK struct {
+	Payload *UsersOwnerGroupsListOKBody
+}
+
+// IsSuccess returns true when this users owner groups list o k response has a 2xx status code
+func (o *UsersOwnerGroupsListOK) IsSuccess() bool {
+	return true
+}
+
+// IsRedirect returns true when this users owner groups list o k response has a 3xx status code
+func (o *UsersOwnerGroupsListOK) IsRedirect() bool {
+	return false
+}
+
+// IsClientError returns true when this users owner groups list o k response has a 4xx status code
+func (o *UsersOwnerGroupsListOK) IsClientError() bool {
+	return false
+}
+
+// IsServerError returns true when this users owner groups list o k response has a 5xx status code
+func (o *UsersOwnerGroupsListOK) IsServerError() bool {
+	return false
+}
+
+// IsCode returns true when this users owner groups list o k response a status code equal to that given
+func (o *UsersOwnerGroupsListOK) IsCode(code int) bool {
+	return code == 200
+}
+
+// Code gets the status code for the users owner groups list o k response
+func (o *UsersOwnerGroupsListOK) Code() int {
+	return 200
+}
+
+func (o *UsersOwnerGroupsListOK) Error() string {
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /users/owner-groups/][%d] usersOwnerGroupsListOK %s", 200, payload)
+}
+
+func (o *UsersOwnerGroupsListOK) String() string {
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /users/owner-groups/][%d] usersOwnerGroupsListOK %s", 200, payload)
+}
+
+func (o *UsersOwnerGroupsListOK) GetPayload() *UsersOwnerGroupsListOKBody {
+	return o.Payload
+}
+
+func (o *UsersOwnerGroupsListOK) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
+
+	o.Payload = new(UsersOwnerGroupsListOKBody)
+
+	// response payload
+	if err := consumer.Consume(response.Body(), o.Payload); err != nil && err != io.EOF {
+		return err
+	}
+
+	return nil
+}
+
+// NewUsersOwnerGroupsListDefault creates a UsersOwnerGroupsListDefault with default headers values
+func NewUsersOwnerGroupsListDefault(code int) *UsersOwnerGroupsListDefault {
+	return &UsersOwnerGroupsListDefault{
+		_statusCode: code,
+	}
+}
+
+/*
+UsersOwnerGroupsListDefault describes a response with status code -1, with default header values.
+
+UsersOwnerGroupsListDefault users owner groups list default
+*/
+type UsersOwnerGroupsListDefault struct {
+	_statusCode int
+
+	Payload interface{}
+}
+
+// IsSuccess returns true when this users owner groups list default response has a 2xx status code
+func (o *UsersOwnerGroupsListDefault) IsSuccess() bool {
+	return o._statusCode/100 == 2
+}
+
+// IsRedirect returns true when this users owner groups list default response has a 3xx status code
+func (o *UsersOwnerGroupsListDefault) IsRedirect() bool {
+	return o._statusCode/100 == 3
+}
+
+// IsClientError returns true when this users owner groups list default response has a 4xx status code
+func (o *UsersOwnerGroupsListDefault) IsClientError() bool {
+	return o._statusCode/100 == 4
+}
+
+// IsServerError returns true when this users owner groups list default response has a 5xx status code
+func (o *UsersOwnerGroupsListDefault) IsServerError() bool {
+	return o._statusCode/100 == 5
+}
+
+// IsCode returns true when this users owner groups list default response a status code equal to that given
+func (o *UsersOwnerGroupsListDefault) IsCode(code int) bool {
+	return o._statusCode == code
+}
+
+// Code gets the status code for the users owner groups list default response
+func (o *UsersOwnerGroupsListDefault) Code() int {
+	return o._statusCode
+}
+
+func (o *UsersOwnerGroupsListDefault) Error() string {
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /users/owner-groups/][%d] users_owner_groups_list default %s", o._statusCode, payload)
+}
+
+func (o *UsersOwnerGroupsListDefault) String() string {
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /users/owner-groups/][%d] users_owner_groups_list default %s", o._statusCode, payload)
+}
+
+func (o *UsersOwnerGroupsListDefault) GetPayload() interface{} {
+	return o.Payload
+}
+
+func (o *UsersOwnerGroupsListDefault) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
+
+	// response payload
+	if err := consumer.Consume(response.Body(), &o.Payload); err != nil && err != io.EOF {
+		return err
+	}
+
+	return nil
+}
+
+/*
+UsersOwnerGroupsListOKBody users owner groups list o k body
+swagger:model UsersOwnerGroupsListOKBody
+*/
+type UsersOwnerGroupsListOKBody struct {
+
+	// count
+	// Required: true
+	Count *int64 `json:"count"`
+
+	// next
+	// Format: uri
+	Next *strfmt.URI `json:"next,omitempty"`
+
+	// previous
+	// Format: uri
+	Previous *strfmt.URI `json:"previous,omitempty"`
+
+	// results
+	// Required: true
+	Results []*models.OwnerGroup `json:"results"`
+}
+
+// Validate validates this usersOwnerGroupsList o k body
+func (o *UsersOwnerGroupsListOKBody) Validate(formats strfmt.Registry) error {
+	var res []error
+
+	if err := o.validateCount(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := o.validateNext(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := o.validatePrevious(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := o.validateResults(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if len(res) > 0 {
+		return errors.CompositeValidationError(res...)
+	}
+	return nil
+}
+
+func (o *UsersOwnerGroupsListOKBody) validateCount(formats strfmt.Registry) error {
+
+	if err := validate.Required("usersOwnerGroupsListOK"+"."+"count", "body", o.Count); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (o *UsersOwnerGroupsListOKBody) validateNext(formats strfmt.Registry) error {
+	if swag.IsZero(o.Next) { // not required
+		return nil
+	}
+
+	if err := validate.FormatOf("usersOwnerGroupsListOK"+"."+"next", "body", "uri", o.Next.String(), formats); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (o *UsersOwnerGroupsListOKBody) validatePrevious(formats strfmt.Registry) error {
+	if swag.IsZero(o.Previous) { // not required
+		return nil
+	}
+
+	if err := validate.FormatOf("usersOwnerGroupsListOK"+"."+"previous", "body", "uri", o.Previous.String(), formats); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (o *UsersOwnerGroupsListOKBody) validateResults(formats strfmt.Registry) error {
+
+	if err := validate.Required("usersOwnerGroupsListOK"+"."+"results", "body", o.Results); err != nil {
+		return err
+	}
+
+	for i := 0; i < len(o.Results); i++ {
+		if swag.IsZero(o.Results[i]) { // not required
+			continue
+		}
+
+		if o.Results[i] != nil {
+			if err := o.Results[i].Validate(formats); err != nil {
+				if ve, ok := err.(*errors.Validation); ok {
+					return ve.ValidateName("usersOwnerGroupsListOK" + "." + "results" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("usersOwnerGroupsListOK" + "." + "results" + "." + strconv.Itoa(i))
+				}
+				return err
+			}
+		}
+
+	}
+
+	return nil
+}
+
+// ContextValidate validate this usersOwnerGroupsList o k body based on the context it is used
+func (o *UsersOwnerGroupsListOKBody) ContextValidate(ctx context.Context, formats strfmt.Registry) error {
+	var res []error
+
+	if err := o.contextValidateResults(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
+	if len(res) > 0 {
+		return errors.CompositeValidationError(res...)
+	}
+	return nil
+}
+
+func (o *UsersOwnerGroupsListOKBody) contextValidateResults(ctx context.Context, formats strfmt.Registry) error {
+
+	for i := 0; i < len(o.Results); i++ {
+
+		if o.Results[i] != nil {
+
+			if swag.IsZero(o.Results[i]) { // not required
+				return nil
+			}
+
+			if err := o.Results[i].ContextValidate(ctx, formats); err != nil {
+				if ve, ok := err.(*errors.Validation); ok {
+					return ve.ValidateName("usersOwnerGroupsListOK" + "." + "results" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("usersOwnerGroupsListOK" + "." + "results" + "." + strconv.Itoa(i))
+				}
+				return err
+			}
+		}
+
+	}
+
+	return nil
+}
+
+// MarshalBinary interface implementation
+func (o *UsersOwnerGroupsListOKBody) MarshalBinary() ([]byte, error) {
+	if o == nil {
+		return nil, nil
+	}
+	return swag.WriteJSON(o)
+}
+
+// UnmarshalBinary interface implementation
+func (o *UsersOwnerGroupsListOKBody) UnmarshalBinary(b []byte) error {
+	var res UsersOwnerGroupsListOKBody
+	if err := swag.ReadJSON(b, &res); err != nil {
+		return err
+	}
+	*o = res
+	return nil
+}

--- a/netbox/client/users/users_owner_groups_partial_update_parameters.go
+++ b/netbox/client/users/users_owner_groups_partial_update_parameters.go
@@ -1,0 +1,187 @@
+// Copyright 2020 The go-netbox Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package users
+
+// This file was manually added to extend the client with NetBox's Owner/OwnerGroup
+// endpoints (netbox-community/netbox users app), which are not yet covered by the
+// upstream swagger-generated client.
+
+import (
+	"context"
+	"net/http"
+	"time"
+
+	"github.com/go-openapi/errors"
+	"github.com/go-openapi/runtime"
+	cr "github.com/go-openapi/runtime/client"
+	"github.com/go-openapi/strfmt"
+	"github.com/go-openapi/swag"
+
+	"github.com/fbreckle/go-netbox/netbox/models"
+)
+
+// NewUsersOwnerGroupsPartialUpdateParams creates a new UsersOwnerGroupsPartialUpdateParams object,
+// with the default timeout for this client.
+//
+// Default values are not hydrated, since defaults are normally applied by the API server side.
+//
+// To enforce default values in parameter, use SetDefaults or WithDefaults.
+func NewUsersOwnerGroupsPartialUpdateParams() *UsersOwnerGroupsPartialUpdateParams {
+	return &UsersOwnerGroupsPartialUpdateParams{
+		timeout: cr.DefaultTimeout,
+	}
+}
+
+// NewUsersOwnerGroupsPartialUpdateParamsWithTimeout creates a new UsersOwnerGroupsPartialUpdateParams object
+// with the ability to set a timeout on a request.
+func NewUsersOwnerGroupsPartialUpdateParamsWithTimeout(timeout time.Duration) *UsersOwnerGroupsPartialUpdateParams {
+	return &UsersOwnerGroupsPartialUpdateParams{
+		timeout: timeout,
+	}
+}
+
+// NewUsersOwnerGroupsPartialUpdateParamsWithContext creates a new UsersOwnerGroupsPartialUpdateParams object
+// with the ability to set a context for a request.
+func NewUsersOwnerGroupsPartialUpdateParamsWithContext(ctx context.Context) *UsersOwnerGroupsPartialUpdateParams {
+	return &UsersOwnerGroupsPartialUpdateParams{
+		Context: ctx,
+	}
+}
+
+// NewUsersOwnerGroupsPartialUpdateParamsWithHTTPClient creates a new UsersOwnerGroupsPartialUpdateParams object
+// with the ability to set a custom HTTPClient for a request.
+func NewUsersOwnerGroupsPartialUpdateParamsWithHTTPClient(client *http.Client) *UsersOwnerGroupsPartialUpdateParams {
+	return &UsersOwnerGroupsPartialUpdateParams{
+		HTTPClient: client,
+	}
+}
+
+/*
+UsersOwnerGroupsPartialUpdateParams contains all the parameters to send to the API endpoint
+
+	for the users owner groups partial update operation.
+
+	Typically these are written to a http.Request.
+*/
+type UsersOwnerGroupsPartialUpdateParams struct {
+
+	// Data.
+	Data *models.OwnerGroup
+
+	/* ID.
+
+	   A unique integer value identifying this owner group.
+	*/
+	ID int64
+
+	timeout    time.Duration
+	Context    context.Context
+	HTTPClient *http.Client
+}
+
+// WithDefaults hydrates default values in the users owner groups partial update params (not the query body).
+//
+// All values with no default are reset to their zero value.
+func (o *UsersOwnerGroupsPartialUpdateParams) WithDefaults() *UsersOwnerGroupsPartialUpdateParams {
+	o.SetDefaults()
+	return o
+}
+
+// SetDefaults hydrates default values in the users owner groups partial update params (not the query body).
+//
+// All values with no default are reset to their zero value.
+func (o *UsersOwnerGroupsPartialUpdateParams) SetDefaults() {
+	// no default values defined for this parameter
+}
+
+// WithTimeout adds the timeout to the users owner groups partial update params
+func (o *UsersOwnerGroupsPartialUpdateParams) WithTimeout(timeout time.Duration) *UsersOwnerGroupsPartialUpdateParams {
+	o.SetTimeout(timeout)
+	return o
+}
+
+// SetTimeout adds the timeout to the users owner groups partial update params
+func (o *UsersOwnerGroupsPartialUpdateParams) SetTimeout(timeout time.Duration) {
+	o.timeout = timeout
+}
+
+// WithContext adds the context to the users owner groups partial update params
+func (o *UsersOwnerGroupsPartialUpdateParams) WithContext(ctx context.Context) *UsersOwnerGroupsPartialUpdateParams {
+	o.SetContext(ctx)
+	return o
+}
+
+// SetContext adds the context to the users owner groups partial update params
+func (o *UsersOwnerGroupsPartialUpdateParams) SetContext(ctx context.Context) {
+	o.Context = ctx
+}
+
+// WithHTTPClient adds the HTTPClient to the users owner groups partial update params
+func (o *UsersOwnerGroupsPartialUpdateParams) WithHTTPClient(client *http.Client) *UsersOwnerGroupsPartialUpdateParams {
+	o.SetHTTPClient(client)
+	return o
+}
+
+// SetHTTPClient adds the HTTPClient to the users owner groups partial update params
+func (o *UsersOwnerGroupsPartialUpdateParams) SetHTTPClient(client *http.Client) {
+	o.HTTPClient = client
+}
+
+// WithData adds the data to the users owner groups partial update params
+func (o *UsersOwnerGroupsPartialUpdateParams) WithData(data *models.OwnerGroup) *UsersOwnerGroupsPartialUpdateParams {
+	o.SetData(data)
+	return o
+}
+
+// SetData adds the data to the users owner groups partial update params
+func (o *UsersOwnerGroupsPartialUpdateParams) SetData(data *models.OwnerGroup) {
+	o.Data = data
+}
+
+// WithID adds the id to the users owner groups partial update params
+func (o *UsersOwnerGroupsPartialUpdateParams) WithID(id int64) *UsersOwnerGroupsPartialUpdateParams {
+	o.SetID(id)
+	return o
+}
+
+// SetID adds the id to the users owner groups partial update params
+func (o *UsersOwnerGroupsPartialUpdateParams) SetID(id int64) {
+	o.ID = id
+}
+
+// WriteToRequest writes these params to a swagger request
+func (o *UsersOwnerGroupsPartialUpdateParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.Registry) error {
+
+	if err := r.SetTimeout(o.timeout); err != nil {
+		return err
+	}
+	var res []error
+	if o.Data != nil {
+		if err := r.SetBodyParam(o.Data); err != nil {
+			return err
+		}
+	}
+
+	// path param id
+	if err := r.SetPathParam("id", swag.FormatInt64(o.ID)); err != nil {
+		return err
+	}
+
+	if len(res) > 0 {
+		return errors.CompositeValidationError(res...)
+	}
+	return nil
+}

--- a/netbox/client/users/users_owner_groups_partial_update_responses.go
+++ b/netbox/client/users/users_owner_groups_partial_update_responses.go
@@ -1,0 +1,199 @@
+// Copyright 2020 The go-netbox Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package users
+
+// This file was manually added to extend the client with NetBox's Owner/OwnerGroup
+// endpoints (netbox-community/netbox users app), which are not yet covered by the
+// upstream swagger-generated client.
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+
+	"github.com/go-openapi/runtime"
+	"github.com/go-openapi/strfmt"
+
+	"github.com/fbreckle/go-netbox/netbox/models"
+)
+
+// UsersOwnerGroupsPartialUpdateReader is a Reader for the UsersOwnerGroupsPartialUpdate structure.
+type UsersOwnerGroupsPartialUpdateReader struct {
+	formats strfmt.Registry
+}
+
+// ReadResponse reads a server response into the received o.
+func (o *UsersOwnerGroupsPartialUpdateReader) ReadResponse(response runtime.ClientResponse, consumer runtime.Consumer) (interface{}, error) {
+	switch response.Code() {
+	case 200:
+		result := NewUsersOwnerGroupsPartialUpdateOK()
+		if err := result.readResponse(response, consumer, o.formats); err != nil {
+			return nil, err
+		}
+		return result, nil
+	default:
+		result := NewUsersOwnerGroupsPartialUpdateDefault(response.Code())
+		if err := result.readResponse(response, consumer, o.formats); err != nil {
+			return nil, err
+		}
+		if response.Code()/100 == 2 {
+			return result, nil
+		}
+		return nil, result
+	}
+}
+
+// NewUsersOwnerGroupsPartialUpdateOK creates a UsersOwnerGroupsPartialUpdateOK with default headers values
+func NewUsersOwnerGroupsPartialUpdateOK() *UsersOwnerGroupsPartialUpdateOK {
+	return &UsersOwnerGroupsPartialUpdateOK{}
+}
+
+/*
+UsersOwnerGroupsPartialUpdateOK describes a response with status code 200, with default header values.
+
+UsersOwnerGroupsPartialUpdateOK users owner groups partial update o k
+*/
+type UsersOwnerGroupsPartialUpdateOK struct {
+	Payload *models.OwnerGroup
+}
+
+// IsSuccess returns true when this users owner groups partial update o k response has a 2xx status code
+func (o *UsersOwnerGroupsPartialUpdateOK) IsSuccess() bool {
+	return true
+}
+
+// IsRedirect returns true when this users owner groups partial update o k response has a 3xx status code
+func (o *UsersOwnerGroupsPartialUpdateOK) IsRedirect() bool {
+	return false
+}
+
+// IsClientError returns true when this users owner groups partial update o k response has a 4xx status code
+func (o *UsersOwnerGroupsPartialUpdateOK) IsClientError() bool {
+	return false
+}
+
+// IsServerError returns true when this users owner groups partial update o k response has a 5xx status code
+func (o *UsersOwnerGroupsPartialUpdateOK) IsServerError() bool {
+	return false
+}
+
+// IsCode returns true when this users owner groups partial update o k response a status code equal to that given
+func (o *UsersOwnerGroupsPartialUpdateOK) IsCode(code int) bool {
+	return code == 200
+}
+
+// Code gets the status code for the users owner groups partial update o k response
+func (o *UsersOwnerGroupsPartialUpdateOK) Code() int {
+	return 200
+}
+
+func (o *UsersOwnerGroupsPartialUpdateOK) Error() string {
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[PATCH /users/owner-groups/{id}/][%d] usersOwnerGroupsPartialUpdateOK %s", 200, payload)
+}
+
+func (o *UsersOwnerGroupsPartialUpdateOK) String() string {
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[PATCH /users/owner-groups/{id}/][%d] usersOwnerGroupsPartialUpdateOK %s", 200, payload)
+}
+
+func (o *UsersOwnerGroupsPartialUpdateOK) GetPayload() *models.OwnerGroup {
+	return o.Payload
+}
+
+func (o *UsersOwnerGroupsPartialUpdateOK) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
+
+	o.Payload = new(models.OwnerGroup)
+
+	// response payload
+	if err := consumer.Consume(response.Body(), o.Payload); err != nil && err != io.EOF {
+		return err
+	}
+
+	return nil
+}
+
+// NewUsersOwnerGroupsPartialUpdateDefault creates a UsersOwnerGroupsPartialUpdateDefault with default headers values
+func NewUsersOwnerGroupsPartialUpdateDefault(code int) *UsersOwnerGroupsPartialUpdateDefault {
+	return &UsersOwnerGroupsPartialUpdateDefault{
+		_statusCode: code,
+	}
+}
+
+/*
+UsersOwnerGroupsPartialUpdateDefault describes a response with status code -1, with default header values.
+
+UsersOwnerGroupsPartialUpdateDefault users owner groups partial update default
+*/
+type UsersOwnerGroupsPartialUpdateDefault struct {
+	_statusCode int
+
+	Payload interface{}
+}
+
+// IsSuccess returns true when this users owner groups partial update default response has a 2xx status code
+func (o *UsersOwnerGroupsPartialUpdateDefault) IsSuccess() bool {
+	return o._statusCode/100 == 2
+}
+
+// IsRedirect returns true when this users owner groups partial update default response has a 3xx status code
+func (o *UsersOwnerGroupsPartialUpdateDefault) IsRedirect() bool {
+	return o._statusCode/100 == 3
+}
+
+// IsClientError returns true when this users owner groups partial update default response has a 4xx status code
+func (o *UsersOwnerGroupsPartialUpdateDefault) IsClientError() bool {
+	return o._statusCode/100 == 4
+}
+
+// IsServerError returns true when this users owner groups partial update default response has a 5xx status code
+func (o *UsersOwnerGroupsPartialUpdateDefault) IsServerError() bool {
+	return o._statusCode/100 == 5
+}
+
+// IsCode returns true when this users owner groups partial update default response a status code equal to that given
+func (o *UsersOwnerGroupsPartialUpdateDefault) IsCode(code int) bool {
+	return o._statusCode == code
+}
+
+// Code gets the status code for the users owner groups partial update default response
+func (o *UsersOwnerGroupsPartialUpdateDefault) Code() int {
+	return o._statusCode
+}
+
+func (o *UsersOwnerGroupsPartialUpdateDefault) Error() string {
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[PATCH /users/owner-groups/{id}/][%d] users_owner_groups_partial_update default %s", o._statusCode, payload)
+}
+
+func (o *UsersOwnerGroupsPartialUpdateDefault) String() string {
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[PATCH /users/owner-groups/{id}/][%d] users_owner_groups_partial_update default %s", o._statusCode, payload)
+}
+
+func (o *UsersOwnerGroupsPartialUpdateDefault) GetPayload() interface{} {
+	return o.Payload
+}
+
+func (o *UsersOwnerGroupsPartialUpdateDefault) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
+
+	// response payload
+	if err := consumer.Consume(response.Body(), &o.Payload); err != nil && err != io.EOF {
+		return err
+	}
+
+	return nil
+}

--- a/netbox/client/users/users_owner_groups_read_parameters.go
+++ b/netbox/client/users/users_owner_groups_read_parameters.go
@@ -1,0 +1,166 @@
+// Copyright 2020 The go-netbox Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package users
+
+// This file was manually added to extend the client with NetBox's Owner/OwnerGroup
+// endpoints (netbox-community/netbox users app), which are not yet covered by the
+// upstream swagger-generated client.
+
+import (
+	"context"
+	"net/http"
+	"time"
+
+	"github.com/go-openapi/errors"
+	"github.com/go-openapi/runtime"
+	cr "github.com/go-openapi/runtime/client"
+	"github.com/go-openapi/strfmt"
+	"github.com/go-openapi/swag"
+)
+
+// NewUsersOwnerGroupsReadParams creates a new UsersOwnerGroupsReadParams object,
+// with the default timeout for this client.
+//
+// Default values are not hydrated, since defaults are normally applied by the API server side.
+//
+// To enforce default values in parameter, use SetDefaults or WithDefaults.
+func NewUsersOwnerGroupsReadParams() *UsersOwnerGroupsReadParams {
+	return &UsersOwnerGroupsReadParams{
+		timeout: cr.DefaultTimeout,
+	}
+}
+
+// NewUsersOwnerGroupsReadParamsWithTimeout creates a new UsersOwnerGroupsReadParams object
+// with the ability to set a timeout on a request.
+func NewUsersOwnerGroupsReadParamsWithTimeout(timeout time.Duration) *UsersOwnerGroupsReadParams {
+	return &UsersOwnerGroupsReadParams{
+		timeout: timeout,
+	}
+}
+
+// NewUsersOwnerGroupsReadParamsWithContext creates a new UsersOwnerGroupsReadParams object
+// with the ability to set a context for a request.
+func NewUsersOwnerGroupsReadParamsWithContext(ctx context.Context) *UsersOwnerGroupsReadParams {
+	return &UsersOwnerGroupsReadParams{
+		Context: ctx,
+	}
+}
+
+// NewUsersOwnerGroupsReadParamsWithHTTPClient creates a new UsersOwnerGroupsReadParams object
+// with the ability to set a custom HTTPClient for a request.
+func NewUsersOwnerGroupsReadParamsWithHTTPClient(client *http.Client) *UsersOwnerGroupsReadParams {
+	return &UsersOwnerGroupsReadParams{
+		HTTPClient: client,
+	}
+}
+
+/*
+UsersOwnerGroupsReadParams contains all the parameters to send to the API endpoint
+
+	for the users owner groups read operation.
+
+	Typically these are written to a http.Request.
+*/
+type UsersOwnerGroupsReadParams struct {
+
+	/* ID.
+
+	   A unique integer value identifying this owner group.
+	*/
+	ID int64
+
+	timeout    time.Duration
+	Context    context.Context
+	HTTPClient *http.Client
+}
+
+// WithDefaults hydrates default values in the users owner groups read params (not the query body).
+//
+// All values with no default are reset to their zero value.
+func (o *UsersOwnerGroupsReadParams) WithDefaults() *UsersOwnerGroupsReadParams {
+	o.SetDefaults()
+	return o
+}
+
+// SetDefaults hydrates default values in the users owner groups read params (not the query body).
+//
+// All values with no default are reset to their zero value.
+func (o *UsersOwnerGroupsReadParams) SetDefaults() {
+	// no default values defined for this parameter
+}
+
+// WithTimeout adds the timeout to the users owner groups read params
+func (o *UsersOwnerGroupsReadParams) WithTimeout(timeout time.Duration) *UsersOwnerGroupsReadParams {
+	o.SetTimeout(timeout)
+	return o
+}
+
+// SetTimeout adds the timeout to the users owner groups read params
+func (o *UsersOwnerGroupsReadParams) SetTimeout(timeout time.Duration) {
+	o.timeout = timeout
+}
+
+// WithContext adds the context to the users owner groups read params
+func (o *UsersOwnerGroupsReadParams) WithContext(ctx context.Context) *UsersOwnerGroupsReadParams {
+	o.SetContext(ctx)
+	return o
+}
+
+// SetContext adds the context to the users owner groups read params
+func (o *UsersOwnerGroupsReadParams) SetContext(ctx context.Context) {
+	o.Context = ctx
+}
+
+// WithHTTPClient adds the HTTPClient to the users owner groups read params
+func (o *UsersOwnerGroupsReadParams) WithHTTPClient(client *http.Client) *UsersOwnerGroupsReadParams {
+	o.SetHTTPClient(client)
+	return o
+}
+
+// SetHTTPClient adds the HTTPClient to the users owner groups read params
+func (o *UsersOwnerGroupsReadParams) SetHTTPClient(client *http.Client) {
+	o.HTTPClient = client
+}
+
+// WithID adds the id to the users owner groups read params
+func (o *UsersOwnerGroupsReadParams) WithID(id int64) *UsersOwnerGroupsReadParams {
+	o.SetID(id)
+	return o
+}
+
+// SetID adds the id to the users owner groups read params
+func (o *UsersOwnerGroupsReadParams) SetID(id int64) {
+	o.ID = id
+}
+
+// WriteToRequest writes these params to a swagger request
+func (o *UsersOwnerGroupsReadParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.Registry) error {
+
+	if err := r.SetTimeout(o.timeout); err != nil {
+		return err
+	}
+	var res []error
+
+	// path param id
+	if err := r.SetPathParam("id", swag.FormatInt64(o.ID)); err != nil {
+		return err
+	}
+
+	if len(res) > 0 {
+		return errors.CompositeValidationError(res...)
+	}
+	return nil
+}

--- a/netbox/client/users/users_owner_groups_read_responses.go
+++ b/netbox/client/users/users_owner_groups_read_responses.go
@@ -1,0 +1,199 @@
+// Copyright 2020 The go-netbox Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package users
+
+// This file was manually added to extend the client with NetBox's Owner/OwnerGroup
+// endpoints (netbox-community/netbox users app), which are not yet covered by the
+// upstream swagger-generated client.
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+
+	"github.com/go-openapi/runtime"
+	"github.com/go-openapi/strfmt"
+
+	"github.com/fbreckle/go-netbox/netbox/models"
+)
+
+// UsersOwnerGroupsReadReader is a Reader for the UsersOwnerGroupsRead structure.
+type UsersOwnerGroupsReadReader struct {
+	formats strfmt.Registry
+}
+
+// ReadResponse reads a server response into the received o.
+func (o *UsersOwnerGroupsReadReader) ReadResponse(response runtime.ClientResponse, consumer runtime.Consumer) (interface{}, error) {
+	switch response.Code() {
+	case 200:
+		result := NewUsersOwnerGroupsReadOK()
+		if err := result.readResponse(response, consumer, o.formats); err != nil {
+			return nil, err
+		}
+		return result, nil
+	default:
+		result := NewUsersOwnerGroupsReadDefault(response.Code())
+		if err := result.readResponse(response, consumer, o.formats); err != nil {
+			return nil, err
+		}
+		if response.Code()/100 == 2 {
+			return result, nil
+		}
+		return nil, result
+	}
+}
+
+// NewUsersOwnerGroupsReadOK creates a UsersOwnerGroupsReadOK with default headers values
+func NewUsersOwnerGroupsReadOK() *UsersOwnerGroupsReadOK {
+	return &UsersOwnerGroupsReadOK{}
+}
+
+/*
+UsersOwnerGroupsReadOK describes a response with status code 200, with default header values.
+
+UsersOwnerGroupsReadOK users owner groups read o k
+*/
+type UsersOwnerGroupsReadOK struct {
+	Payload *models.OwnerGroup
+}
+
+// IsSuccess returns true when this users owner groups read o k response has a 2xx status code
+func (o *UsersOwnerGroupsReadOK) IsSuccess() bool {
+	return true
+}
+
+// IsRedirect returns true when this users owner groups read o k response has a 3xx status code
+func (o *UsersOwnerGroupsReadOK) IsRedirect() bool {
+	return false
+}
+
+// IsClientError returns true when this users owner groups read o k response has a 4xx status code
+func (o *UsersOwnerGroupsReadOK) IsClientError() bool {
+	return false
+}
+
+// IsServerError returns true when this users owner groups read o k response has a 5xx status code
+func (o *UsersOwnerGroupsReadOK) IsServerError() bool {
+	return false
+}
+
+// IsCode returns true when this users owner groups read o k response a status code equal to that given
+func (o *UsersOwnerGroupsReadOK) IsCode(code int) bool {
+	return code == 200
+}
+
+// Code gets the status code for the users owner groups read o k response
+func (o *UsersOwnerGroupsReadOK) Code() int {
+	return 200
+}
+
+func (o *UsersOwnerGroupsReadOK) Error() string {
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /users/owner-groups/{id}/][%d] usersOwnerGroupsReadOK %s", 200, payload)
+}
+
+func (o *UsersOwnerGroupsReadOK) String() string {
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /users/owner-groups/{id}/][%d] usersOwnerGroupsReadOK %s", 200, payload)
+}
+
+func (o *UsersOwnerGroupsReadOK) GetPayload() *models.OwnerGroup {
+	return o.Payload
+}
+
+func (o *UsersOwnerGroupsReadOK) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
+
+	o.Payload = new(models.OwnerGroup)
+
+	// response payload
+	if err := consumer.Consume(response.Body(), o.Payload); err != nil && err != io.EOF {
+		return err
+	}
+
+	return nil
+}
+
+// NewUsersOwnerGroupsReadDefault creates a UsersOwnerGroupsReadDefault with default headers values
+func NewUsersOwnerGroupsReadDefault(code int) *UsersOwnerGroupsReadDefault {
+	return &UsersOwnerGroupsReadDefault{
+		_statusCode: code,
+	}
+}
+
+/*
+UsersOwnerGroupsReadDefault describes a response with status code -1, with default header values.
+
+UsersOwnerGroupsReadDefault users owner groups read default
+*/
+type UsersOwnerGroupsReadDefault struct {
+	_statusCode int
+
+	Payload interface{}
+}
+
+// IsSuccess returns true when this users owner groups read default response has a 2xx status code
+func (o *UsersOwnerGroupsReadDefault) IsSuccess() bool {
+	return o._statusCode/100 == 2
+}
+
+// IsRedirect returns true when this users owner groups read default response has a 3xx status code
+func (o *UsersOwnerGroupsReadDefault) IsRedirect() bool {
+	return o._statusCode/100 == 3
+}
+
+// IsClientError returns true when this users owner groups read default response has a 4xx status code
+func (o *UsersOwnerGroupsReadDefault) IsClientError() bool {
+	return o._statusCode/100 == 4
+}
+
+// IsServerError returns true when this users owner groups read default response has a 5xx status code
+func (o *UsersOwnerGroupsReadDefault) IsServerError() bool {
+	return o._statusCode/100 == 5
+}
+
+// IsCode returns true when this users owner groups read default response a status code equal to that given
+func (o *UsersOwnerGroupsReadDefault) IsCode(code int) bool {
+	return o._statusCode == code
+}
+
+// Code gets the status code for the users owner groups read default response
+func (o *UsersOwnerGroupsReadDefault) Code() int {
+	return o._statusCode
+}
+
+func (o *UsersOwnerGroupsReadDefault) Error() string {
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /users/owner-groups/{id}/][%d] users_owner_groups_read default %s", o._statusCode, payload)
+}
+
+func (o *UsersOwnerGroupsReadDefault) String() string {
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /users/owner-groups/{id}/][%d] users_owner_groups_read default %s", o._statusCode, payload)
+}
+
+func (o *UsersOwnerGroupsReadDefault) GetPayload() interface{} {
+	return o.Payload
+}
+
+func (o *UsersOwnerGroupsReadDefault) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
+
+	// response payload
+	if err := consumer.Consume(response.Body(), &o.Payload); err != nil && err != io.EOF {
+		return err
+	}
+
+	return nil
+}

--- a/netbox/client/users/users_owner_groups_update_parameters.go
+++ b/netbox/client/users/users_owner_groups_update_parameters.go
@@ -1,0 +1,187 @@
+// Copyright 2020 The go-netbox Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package users
+
+// This file was manually added to extend the client with NetBox's Owner/OwnerGroup
+// endpoints (netbox-community/netbox users app), which are not yet covered by the
+// upstream swagger-generated client.
+
+import (
+	"context"
+	"net/http"
+	"time"
+
+	"github.com/go-openapi/errors"
+	"github.com/go-openapi/runtime"
+	cr "github.com/go-openapi/runtime/client"
+	"github.com/go-openapi/strfmt"
+	"github.com/go-openapi/swag"
+
+	"github.com/fbreckle/go-netbox/netbox/models"
+)
+
+// NewUsersOwnerGroupsUpdateParams creates a new UsersOwnerGroupsUpdateParams object,
+// with the default timeout for this client.
+//
+// Default values are not hydrated, since defaults are normally applied by the API server side.
+//
+// To enforce default values in parameter, use SetDefaults or WithDefaults.
+func NewUsersOwnerGroupsUpdateParams() *UsersOwnerGroupsUpdateParams {
+	return &UsersOwnerGroupsUpdateParams{
+		timeout: cr.DefaultTimeout,
+	}
+}
+
+// NewUsersOwnerGroupsUpdateParamsWithTimeout creates a new UsersOwnerGroupsUpdateParams object
+// with the ability to set a timeout on a request.
+func NewUsersOwnerGroupsUpdateParamsWithTimeout(timeout time.Duration) *UsersOwnerGroupsUpdateParams {
+	return &UsersOwnerGroupsUpdateParams{
+		timeout: timeout,
+	}
+}
+
+// NewUsersOwnerGroupsUpdateParamsWithContext creates a new UsersOwnerGroupsUpdateParams object
+// with the ability to set a context for a request.
+func NewUsersOwnerGroupsUpdateParamsWithContext(ctx context.Context) *UsersOwnerGroupsUpdateParams {
+	return &UsersOwnerGroupsUpdateParams{
+		Context: ctx,
+	}
+}
+
+// NewUsersOwnerGroupsUpdateParamsWithHTTPClient creates a new UsersOwnerGroupsUpdateParams object
+// with the ability to set a custom HTTPClient for a request.
+func NewUsersOwnerGroupsUpdateParamsWithHTTPClient(client *http.Client) *UsersOwnerGroupsUpdateParams {
+	return &UsersOwnerGroupsUpdateParams{
+		HTTPClient: client,
+	}
+}
+
+/*
+UsersOwnerGroupsUpdateParams contains all the parameters to send to the API endpoint
+
+	for the users owner groups update operation.
+
+	Typically these are written to a http.Request.
+*/
+type UsersOwnerGroupsUpdateParams struct {
+
+	// Data.
+	Data *models.OwnerGroup
+
+	/* ID.
+
+	   A unique integer value identifying this owner group.
+	*/
+	ID int64
+
+	timeout    time.Duration
+	Context    context.Context
+	HTTPClient *http.Client
+}
+
+// WithDefaults hydrates default values in the users owner groups update params (not the query body).
+//
+// All values with no default are reset to their zero value.
+func (o *UsersOwnerGroupsUpdateParams) WithDefaults() *UsersOwnerGroupsUpdateParams {
+	o.SetDefaults()
+	return o
+}
+
+// SetDefaults hydrates default values in the users owner groups update params (not the query body).
+//
+// All values with no default are reset to their zero value.
+func (o *UsersOwnerGroupsUpdateParams) SetDefaults() {
+	// no default values defined for this parameter
+}
+
+// WithTimeout adds the timeout to the users owner groups update params
+func (o *UsersOwnerGroupsUpdateParams) WithTimeout(timeout time.Duration) *UsersOwnerGroupsUpdateParams {
+	o.SetTimeout(timeout)
+	return o
+}
+
+// SetTimeout adds the timeout to the users owner groups update params
+func (o *UsersOwnerGroupsUpdateParams) SetTimeout(timeout time.Duration) {
+	o.timeout = timeout
+}
+
+// WithContext adds the context to the users owner groups update params
+func (o *UsersOwnerGroupsUpdateParams) WithContext(ctx context.Context) *UsersOwnerGroupsUpdateParams {
+	o.SetContext(ctx)
+	return o
+}
+
+// SetContext adds the context to the users owner groups update params
+func (o *UsersOwnerGroupsUpdateParams) SetContext(ctx context.Context) {
+	o.Context = ctx
+}
+
+// WithHTTPClient adds the HTTPClient to the users owner groups update params
+func (o *UsersOwnerGroupsUpdateParams) WithHTTPClient(client *http.Client) *UsersOwnerGroupsUpdateParams {
+	o.SetHTTPClient(client)
+	return o
+}
+
+// SetHTTPClient adds the HTTPClient to the users owner groups update params
+func (o *UsersOwnerGroupsUpdateParams) SetHTTPClient(client *http.Client) {
+	o.HTTPClient = client
+}
+
+// WithData adds the data to the users owner groups update params
+func (o *UsersOwnerGroupsUpdateParams) WithData(data *models.OwnerGroup) *UsersOwnerGroupsUpdateParams {
+	o.SetData(data)
+	return o
+}
+
+// SetData adds the data to the users owner groups update params
+func (o *UsersOwnerGroupsUpdateParams) SetData(data *models.OwnerGroup) {
+	o.Data = data
+}
+
+// WithID adds the id to the users owner groups update params
+func (o *UsersOwnerGroupsUpdateParams) WithID(id int64) *UsersOwnerGroupsUpdateParams {
+	o.SetID(id)
+	return o
+}
+
+// SetID adds the id to the users owner groups update params
+func (o *UsersOwnerGroupsUpdateParams) SetID(id int64) {
+	o.ID = id
+}
+
+// WriteToRequest writes these params to a swagger request
+func (o *UsersOwnerGroupsUpdateParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.Registry) error {
+
+	if err := r.SetTimeout(o.timeout); err != nil {
+		return err
+	}
+	var res []error
+	if o.Data != nil {
+		if err := r.SetBodyParam(o.Data); err != nil {
+			return err
+		}
+	}
+
+	// path param id
+	if err := r.SetPathParam("id", swag.FormatInt64(o.ID)); err != nil {
+		return err
+	}
+
+	if len(res) > 0 {
+		return errors.CompositeValidationError(res...)
+	}
+	return nil
+}

--- a/netbox/client/users/users_owner_groups_update_responses.go
+++ b/netbox/client/users/users_owner_groups_update_responses.go
@@ -1,0 +1,199 @@
+// Copyright 2020 The go-netbox Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package users
+
+// This file was manually added to extend the client with NetBox's Owner/OwnerGroup
+// endpoints (netbox-community/netbox users app), which are not yet covered by the
+// upstream swagger-generated client.
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+
+	"github.com/go-openapi/runtime"
+	"github.com/go-openapi/strfmt"
+
+	"github.com/fbreckle/go-netbox/netbox/models"
+)
+
+// UsersOwnerGroupsUpdateReader is a Reader for the UsersOwnerGroupsUpdate structure.
+type UsersOwnerGroupsUpdateReader struct {
+	formats strfmt.Registry
+}
+
+// ReadResponse reads a server response into the received o.
+func (o *UsersOwnerGroupsUpdateReader) ReadResponse(response runtime.ClientResponse, consumer runtime.Consumer) (interface{}, error) {
+	switch response.Code() {
+	case 200:
+		result := NewUsersOwnerGroupsUpdateOK()
+		if err := result.readResponse(response, consumer, o.formats); err != nil {
+			return nil, err
+		}
+		return result, nil
+	default:
+		result := NewUsersOwnerGroupsUpdateDefault(response.Code())
+		if err := result.readResponse(response, consumer, o.formats); err != nil {
+			return nil, err
+		}
+		if response.Code()/100 == 2 {
+			return result, nil
+		}
+		return nil, result
+	}
+}
+
+// NewUsersOwnerGroupsUpdateOK creates a UsersOwnerGroupsUpdateOK with default headers values
+func NewUsersOwnerGroupsUpdateOK() *UsersOwnerGroupsUpdateOK {
+	return &UsersOwnerGroupsUpdateOK{}
+}
+
+/*
+UsersOwnerGroupsUpdateOK describes a response with status code 200, with default header values.
+
+UsersOwnerGroupsUpdateOK users owner groups update o k
+*/
+type UsersOwnerGroupsUpdateOK struct {
+	Payload *models.OwnerGroup
+}
+
+// IsSuccess returns true when this users owner groups update o k response has a 2xx status code
+func (o *UsersOwnerGroupsUpdateOK) IsSuccess() bool {
+	return true
+}
+
+// IsRedirect returns true when this users owner groups update o k response has a 3xx status code
+func (o *UsersOwnerGroupsUpdateOK) IsRedirect() bool {
+	return false
+}
+
+// IsClientError returns true when this users owner groups update o k response has a 4xx status code
+func (o *UsersOwnerGroupsUpdateOK) IsClientError() bool {
+	return false
+}
+
+// IsServerError returns true when this users owner groups update o k response has a 5xx status code
+func (o *UsersOwnerGroupsUpdateOK) IsServerError() bool {
+	return false
+}
+
+// IsCode returns true when this users owner groups update o k response a status code equal to that given
+func (o *UsersOwnerGroupsUpdateOK) IsCode(code int) bool {
+	return code == 200
+}
+
+// Code gets the status code for the users owner groups update o k response
+func (o *UsersOwnerGroupsUpdateOK) Code() int {
+	return 200
+}
+
+func (o *UsersOwnerGroupsUpdateOK) Error() string {
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[PUT /users/owner-groups/{id}/][%d] usersOwnerGroupsUpdateOK %s", 200, payload)
+}
+
+func (o *UsersOwnerGroupsUpdateOK) String() string {
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[PUT /users/owner-groups/{id}/][%d] usersOwnerGroupsUpdateOK %s", 200, payload)
+}
+
+func (o *UsersOwnerGroupsUpdateOK) GetPayload() *models.OwnerGroup {
+	return o.Payload
+}
+
+func (o *UsersOwnerGroupsUpdateOK) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
+
+	o.Payload = new(models.OwnerGroup)
+
+	// response payload
+	if err := consumer.Consume(response.Body(), o.Payload); err != nil && err != io.EOF {
+		return err
+	}
+
+	return nil
+}
+
+// NewUsersOwnerGroupsUpdateDefault creates a UsersOwnerGroupsUpdateDefault with default headers values
+func NewUsersOwnerGroupsUpdateDefault(code int) *UsersOwnerGroupsUpdateDefault {
+	return &UsersOwnerGroupsUpdateDefault{
+		_statusCode: code,
+	}
+}
+
+/*
+UsersOwnerGroupsUpdateDefault describes a response with status code -1, with default header values.
+
+UsersOwnerGroupsUpdateDefault users owner groups update default
+*/
+type UsersOwnerGroupsUpdateDefault struct {
+	_statusCode int
+
+	Payload interface{}
+}
+
+// IsSuccess returns true when this users owner groups update default response has a 2xx status code
+func (o *UsersOwnerGroupsUpdateDefault) IsSuccess() bool {
+	return o._statusCode/100 == 2
+}
+
+// IsRedirect returns true when this users owner groups update default response has a 3xx status code
+func (o *UsersOwnerGroupsUpdateDefault) IsRedirect() bool {
+	return o._statusCode/100 == 3
+}
+
+// IsClientError returns true when this users owner groups update default response has a 4xx status code
+func (o *UsersOwnerGroupsUpdateDefault) IsClientError() bool {
+	return o._statusCode/100 == 4
+}
+
+// IsServerError returns true when this users owner groups update default response has a 5xx status code
+func (o *UsersOwnerGroupsUpdateDefault) IsServerError() bool {
+	return o._statusCode/100 == 5
+}
+
+// IsCode returns true when this users owner groups update default response a status code equal to that given
+func (o *UsersOwnerGroupsUpdateDefault) IsCode(code int) bool {
+	return o._statusCode == code
+}
+
+// Code gets the status code for the users owner groups update default response
+func (o *UsersOwnerGroupsUpdateDefault) Code() int {
+	return o._statusCode
+}
+
+func (o *UsersOwnerGroupsUpdateDefault) Error() string {
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[PUT /users/owner-groups/{id}/][%d] users_owner_groups_update default %s", o._statusCode, payload)
+}
+
+func (o *UsersOwnerGroupsUpdateDefault) String() string {
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[PUT /users/owner-groups/{id}/][%d] users_owner_groups_update default %s", o._statusCode, payload)
+}
+
+func (o *UsersOwnerGroupsUpdateDefault) GetPayload() interface{} {
+	return o.Payload
+}
+
+func (o *UsersOwnerGroupsUpdateDefault) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
+
+	// response payload
+	if err := consumer.Consume(response.Body(), &o.Payload); err != nil && err != io.EOF {
+		return err
+	}
+
+	return nil
+}

--- a/netbox/client/users/users_owners_create_parameters.go
+++ b/netbox/client/users/users_owners_create_parameters.go
@@ -1,0 +1,164 @@
+// Copyright 2020 The go-netbox Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package users
+
+// This file was manually added to extend the client with NetBox's Owner/OwnerGroup
+// endpoints (netbox-community/netbox users app), which are not yet covered by the
+// upstream swagger-generated client.
+
+import (
+	"context"
+	"net/http"
+	"time"
+
+	"github.com/go-openapi/errors"
+	"github.com/go-openapi/runtime"
+	cr "github.com/go-openapi/runtime/client"
+	"github.com/go-openapi/strfmt"
+
+	"github.com/fbreckle/go-netbox/netbox/models"
+)
+
+// NewUsersOwnersCreateParams creates a new UsersOwnersCreateParams object,
+// with the default timeout for this client.
+//
+// Default values are not hydrated, since defaults are normally applied by the API server side.
+//
+// To enforce default values in parameter, use SetDefaults or WithDefaults.
+func NewUsersOwnersCreateParams() *UsersOwnersCreateParams {
+	return &UsersOwnersCreateParams{
+		timeout: cr.DefaultTimeout,
+	}
+}
+
+// NewUsersOwnersCreateParamsWithTimeout creates a new UsersOwnersCreateParams object
+// with the ability to set a timeout on a request.
+func NewUsersOwnersCreateParamsWithTimeout(timeout time.Duration) *UsersOwnersCreateParams {
+	return &UsersOwnersCreateParams{
+		timeout: timeout,
+	}
+}
+
+// NewUsersOwnersCreateParamsWithContext creates a new UsersOwnersCreateParams object
+// with the ability to set a context for a request.
+func NewUsersOwnersCreateParamsWithContext(ctx context.Context) *UsersOwnersCreateParams {
+	return &UsersOwnersCreateParams{
+		Context: ctx,
+	}
+}
+
+// NewUsersOwnersCreateParamsWithHTTPClient creates a new UsersOwnersCreateParams object
+// with the ability to set a custom HTTPClient for a request.
+func NewUsersOwnersCreateParamsWithHTTPClient(client *http.Client) *UsersOwnersCreateParams {
+	return &UsersOwnersCreateParams{
+		HTTPClient: client,
+	}
+}
+
+/*
+UsersOwnersCreateParams contains all the parameters to send to the API endpoint
+
+	for the users owners create operation.
+
+	Typically these are written to a http.Request.
+*/
+type UsersOwnersCreateParams struct {
+
+	// Data.
+	Data *models.WritableOwner
+
+	timeout    time.Duration
+	Context    context.Context
+	HTTPClient *http.Client
+}
+
+// WithDefaults hydrates default values in the users owners create params (not the query body).
+//
+// All values with no default are reset to their zero value.
+func (o *UsersOwnersCreateParams) WithDefaults() *UsersOwnersCreateParams {
+	o.SetDefaults()
+	return o
+}
+
+// SetDefaults hydrates default values in the users owners create params (not the query body).
+//
+// All values with no default are reset to their zero value.
+func (o *UsersOwnersCreateParams) SetDefaults() {
+	// no default values defined for this parameter
+}
+
+// WithTimeout adds the timeout to the users owners create params
+func (o *UsersOwnersCreateParams) WithTimeout(timeout time.Duration) *UsersOwnersCreateParams {
+	o.SetTimeout(timeout)
+	return o
+}
+
+// SetTimeout adds the timeout to the users owners create params
+func (o *UsersOwnersCreateParams) SetTimeout(timeout time.Duration) {
+	o.timeout = timeout
+}
+
+// WithContext adds the context to the users owners create params
+func (o *UsersOwnersCreateParams) WithContext(ctx context.Context) *UsersOwnersCreateParams {
+	o.SetContext(ctx)
+	return o
+}
+
+// SetContext adds the context to the users owners create params
+func (o *UsersOwnersCreateParams) SetContext(ctx context.Context) {
+	o.Context = ctx
+}
+
+// WithHTTPClient adds the HTTPClient to the users owners create params
+func (o *UsersOwnersCreateParams) WithHTTPClient(client *http.Client) *UsersOwnersCreateParams {
+	o.SetHTTPClient(client)
+	return o
+}
+
+// SetHTTPClient adds the HTTPClient to the users owners create params
+func (o *UsersOwnersCreateParams) SetHTTPClient(client *http.Client) {
+	o.HTTPClient = client
+}
+
+// WithData adds the data to the users owners create params
+func (o *UsersOwnersCreateParams) WithData(data *models.WritableOwner) *UsersOwnersCreateParams {
+	o.SetData(data)
+	return o
+}
+
+// SetData adds the data to the users owners create params
+func (o *UsersOwnersCreateParams) SetData(data *models.WritableOwner) {
+	o.Data = data
+}
+
+// WriteToRequest writes these params to a swagger request
+func (o *UsersOwnersCreateParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.Registry) error {
+
+	if err := r.SetTimeout(o.timeout); err != nil {
+		return err
+	}
+	var res []error
+	if o.Data != nil {
+		if err := r.SetBodyParam(o.Data); err != nil {
+			return err
+		}
+	}
+
+	if len(res) > 0 {
+		return errors.CompositeValidationError(res...)
+	}
+	return nil
+}

--- a/netbox/client/users/users_owners_create_responses.go
+++ b/netbox/client/users/users_owners_create_responses.go
@@ -67,7 +67,7 @@ UsersOwnersCreateCreated describes a response with status code 201, with default
 UsersOwnersCreateCreated users owners create created
 */
 type UsersOwnersCreateCreated struct {
-	Payload *models.WritableOwner
+	Payload *models.Owner
 }
 
 // IsSuccess returns true when this users owners create created response has a 2xx status code
@@ -110,13 +110,13 @@ func (o *UsersOwnersCreateCreated) String() string {
 	return fmt.Sprintf("[POST /users/owners/][%d] usersOwnersCreateCreated %s", 201, payload)
 }
 
-func (o *UsersOwnersCreateCreated) GetPayload() *models.WritableOwner {
+func (o *UsersOwnersCreateCreated) GetPayload() *models.Owner {
 	return o.Payload
 }
 
 func (o *UsersOwnersCreateCreated) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
 
-	o.Payload = new(models.WritableOwner)
+	o.Payload = new(models.Owner)
 
 	// response payload
 	if err := consumer.Consume(response.Body(), o.Payload); err != nil && err != io.EOF {

--- a/netbox/client/users/users_owners_create_responses.go
+++ b/netbox/client/users/users_owners_create_responses.go
@@ -1,0 +1,199 @@
+// Copyright 2020 The go-netbox Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package users
+
+// This file was manually added to extend the client with NetBox's Owner/OwnerGroup
+// endpoints (netbox-community/netbox users app), which are not yet covered by the
+// upstream swagger-generated client.
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+
+	"github.com/go-openapi/runtime"
+	"github.com/go-openapi/strfmt"
+
+	"github.com/fbreckle/go-netbox/netbox/models"
+)
+
+// UsersOwnersCreateReader is a Reader for the UsersOwnersCreate structure.
+type UsersOwnersCreateReader struct {
+	formats strfmt.Registry
+}
+
+// ReadResponse reads a server response into the received o.
+func (o *UsersOwnersCreateReader) ReadResponse(response runtime.ClientResponse, consumer runtime.Consumer) (interface{}, error) {
+	switch response.Code() {
+	case 201:
+		result := NewUsersOwnersCreateCreated()
+		if err := result.readResponse(response, consumer, o.formats); err != nil {
+			return nil, err
+		}
+		return result, nil
+	default:
+		result := NewUsersOwnersCreateDefault(response.Code())
+		if err := result.readResponse(response, consumer, o.formats); err != nil {
+			return nil, err
+		}
+		if response.Code()/100 == 2 {
+			return result, nil
+		}
+		return nil, result
+	}
+}
+
+// NewUsersOwnersCreateCreated creates a UsersOwnersCreateCreated with default headers values
+func NewUsersOwnersCreateCreated() *UsersOwnersCreateCreated {
+	return &UsersOwnersCreateCreated{}
+}
+
+/*
+UsersOwnersCreateCreated describes a response with status code 201, with default header values.
+
+UsersOwnersCreateCreated users owners create created
+*/
+type UsersOwnersCreateCreated struct {
+	Payload *models.WritableOwner
+}
+
+// IsSuccess returns true when this users owners create created response has a 2xx status code
+func (o *UsersOwnersCreateCreated) IsSuccess() bool {
+	return true
+}
+
+// IsRedirect returns true when this users owners create created response has a 3xx status code
+func (o *UsersOwnersCreateCreated) IsRedirect() bool {
+	return false
+}
+
+// IsClientError returns true when this users owners create created response has a 4xx status code
+func (o *UsersOwnersCreateCreated) IsClientError() bool {
+	return false
+}
+
+// IsServerError returns true when this users owners create created response has a 5xx status code
+func (o *UsersOwnersCreateCreated) IsServerError() bool {
+	return false
+}
+
+// IsCode returns true when this users owners create created response a status code equal to that given
+func (o *UsersOwnersCreateCreated) IsCode(code int) bool {
+	return code == 201
+}
+
+// Code gets the status code for the users owners create created response
+func (o *UsersOwnersCreateCreated) Code() int {
+	return 201
+}
+
+func (o *UsersOwnersCreateCreated) Error() string {
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /users/owners/][%d] usersOwnersCreateCreated %s", 201, payload)
+}
+
+func (o *UsersOwnersCreateCreated) String() string {
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /users/owners/][%d] usersOwnersCreateCreated %s", 201, payload)
+}
+
+func (o *UsersOwnersCreateCreated) GetPayload() *models.WritableOwner {
+	return o.Payload
+}
+
+func (o *UsersOwnersCreateCreated) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
+
+	o.Payload = new(models.WritableOwner)
+
+	// response payload
+	if err := consumer.Consume(response.Body(), o.Payload); err != nil && err != io.EOF {
+		return err
+	}
+
+	return nil
+}
+
+// NewUsersOwnersCreateDefault creates a UsersOwnersCreateDefault with default headers values
+func NewUsersOwnersCreateDefault(code int) *UsersOwnersCreateDefault {
+	return &UsersOwnersCreateDefault{
+		_statusCode: code,
+	}
+}
+
+/*
+UsersOwnersCreateDefault describes a response with status code -1, with default header values.
+
+UsersOwnersCreateDefault users owners create default
+*/
+type UsersOwnersCreateDefault struct {
+	_statusCode int
+
+	Payload interface{}
+}
+
+// IsSuccess returns true when this users owners create default response has a 2xx status code
+func (o *UsersOwnersCreateDefault) IsSuccess() bool {
+	return o._statusCode/100 == 2
+}
+
+// IsRedirect returns true when this users owners create default response has a 3xx status code
+func (o *UsersOwnersCreateDefault) IsRedirect() bool {
+	return o._statusCode/100 == 3
+}
+
+// IsClientError returns true when this users owners create default response has a 4xx status code
+func (o *UsersOwnersCreateDefault) IsClientError() bool {
+	return o._statusCode/100 == 4
+}
+
+// IsServerError returns true when this users owners create default response has a 5xx status code
+func (o *UsersOwnersCreateDefault) IsServerError() bool {
+	return o._statusCode/100 == 5
+}
+
+// IsCode returns true when this users owners create default response a status code equal to that given
+func (o *UsersOwnersCreateDefault) IsCode(code int) bool {
+	return o._statusCode == code
+}
+
+// Code gets the status code for the users owners create default response
+func (o *UsersOwnersCreateDefault) Code() int {
+	return o._statusCode
+}
+
+func (o *UsersOwnersCreateDefault) Error() string {
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /users/owners/][%d] users_owners_create default %s", o._statusCode, payload)
+}
+
+func (o *UsersOwnersCreateDefault) String() string {
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /users/owners/][%d] users_owners_create default %s", o._statusCode, payload)
+}
+
+func (o *UsersOwnersCreateDefault) GetPayload() interface{} {
+	return o.Payload
+}
+
+func (o *UsersOwnersCreateDefault) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
+
+	// response payload
+	if err := consumer.Consume(response.Body(), &o.Payload); err != nil && err != io.EOF {
+		return err
+	}
+
+	return nil
+}

--- a/netbox/client/users/users_owners_delete_parameters.go
+++ b/netbox/client/users/users_owners_delete_parameters.go
@@ -1,0 +1,166 @@
+// Copyright 2020 The go-netbox Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package users
+
+// This file was manually added to extend the client with NetBox's Owner/OwnerGroup
+// endpoints (netbox-community/netbox users app), which are not yet covered by the
+// upstream swagger-generated client.
+
+import (
+	"context"
+	"net/http"
+	"time"
+
+	"github.com/go-openapi/errors"
+	"github.com/go-openapi/runtime"
+	cr "github.com/go-openapi/runtime/client"
+	"github.com/go-openapi/strfmt"
+	"github.com/go-openapi/swag"
+)
+
+// NewUsersOwnersDeleteParams creates a new UsersOwnersDeleteParams object,
+// with the default timeout for this client.
+//
+// Default values are not hydrated, since defaults are normally applied by the API server side.
+//
+// To enforce default values in parameter, use SetDefaults or WithDefaults.
+func NewUsersOwnersDeleteParams() *UsersOwnersDeleteParams {
+	return &UsersOwnersDeleteParams{
+		timeout: cr.DefaultTimeout,
+	}
+}
+
+// NewUsersOwnersDeleteParamsWithTimeout creates a new UsersOwnersDeleteParams object
+// with the ability to set a timeout on a request.
+func NewUsersOwnersDeleteParamsWithTimeout(timeout time.Duration) *UsersOwnersDeleteParams {
+	return &UsersOwnersDeleteParams{
+		timeout: timeout,
+	}
+}
+
+// NewUsersOwnersDeleteParamsWithContext creates a new UsersOwnersDeleteParams object
+// with the ability to set a context for a request.
+func NewUsersOwnersDeleteParamsWithContext(ctx context.Context) *UsersOwnersDeleteParams {
+	return &UsersOwnersDeleteParams{
+		Context: ctx,
+	}
+}
+
+// NewUsersOwnersDeleteParamsWithHTTPClient creates a new UsersOwnersDeleteParams object
+// with the ability to set a custom HTTPClient for a request.
+func NewUsersOwnersDeleteParamsWithHTTPClient(client *http.Client) *UsersOwnersDeleteParams {
+	return &UsersOwnersDeleteParams{
+		HTTPClient: client,
+	}
+}
+
+/*
+UsersOwnersDeleteParams contains all the parameters to send to the API endpoint
+
+	for the users owners delete operation.
+
+	Typically these are written to a http.Request.
+*/
+type UsersOwnersDeleteParams struct {
+
+	/* ID.
+
+	   A unique integer value identifying this owner.
+	*/
+	ID int64
+
+	timeout    time.Duration
+	Context    context.Context
+	HTTPClient *http.Client
+}
+
+// WithDefaults hydrates default values in the users owners delete params (not the query body).
+//
+// All values with no default are reset to their zero value.
+func (o *UsersOwnersDeleteParams) WithDefaults() *UsersOwnersDeleteParams {
+	o.SetDefaults()
+	return o
+}
+
+// SetDefaults hydrates default values in the users owners delete params (not the query body).
+//
+// All values with no default are reset to their zero value.
+func (o *UsersOwnersDeleteParams) SetDefaults() {
+	// no default values defined for this parameter
+}
+
+// WithTimeout adds the timeout to the users owners delete params
+func (o *UsersOwnersDeleteParams) WithTimeout(timeout time.Duration) *UsersOwnersDeleteParams {
+	o.SetTimeout(timeout)
+	return o
+}
+
+// SetTimeout adds the timeout to the users owners delete params
+func (o *UsersOwnersDeleteParams) SetTimeout(timeout time.Duration) {
+	o.timeout = timeout
+}
+
+// WithContext adds the context to the users owners delete params
+func (o *UsersOwnersDeleteParams) WithContext(ctx context.Context) *UsersOwnersDeleteParams {
+	o.SetContext(ctx)
+	return o
+}
+
+// SetContext adds the context to the users owners delete params
+func (o *UsersOwnersDeleteParams) SetContext(ctx context.Context) {
+	o.Context = ctx
+}
+
+// WithHTTPClient adds the HTTPClient to the users owners delete params
+func (o *UsersOwnersDeleteParams) WithHTTPClient(client *http.Client) *UsersOwnersDeleteParams {
+	o.SetHTTPClient(client)
+	return o
+}
+
+// SetHTTPClient adds the HTTPClient to the users owners delete params
+func (o *UsersOwnersDeleteParams) SetHTTPClient(client *http.Client) {
+	o.HTTPClient = client
+}
+
+// WithID adds the id to the users owners delete params
+func (o *UsersOwnersDeleteParams) WithID(id int64) *UsersOwnersDeleteParams {
+	o.SetID(id)
+	return o
+}
+
+// SetID adds the id to the users owners delete params
+func (o *UsersOwnersDeleteParams) SetID(id int64) {
+	o.ID = id
+}
+
+// WriteToRequest writes these params to a swagger request
+func (o *UsersOwnersDeleteParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.Registry) error {
+
+	if err := r.SetTimeout(o.timeout); err != nil {
+		return err
+	}
+	var res []error
+
+	// path param id
+	if err := r.SetPathParam("id", swag.FormatInt64(o.ID)); err != nil {
+		return err
+	}
+
+	if len(res) > 0 {
+		return errors.CompositeValidationError(res...)
+	}
+	return nil
+}

--- a/netbox/client/users/users_owners_delete_responses.go
+++ b/netbox/client/users/users_owners_delete_responses.go
@@ -1,0 +1,183 @@
+// Copyright 2020 The go-netbox Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package users
+
+// This file was manually added to extend the client with NetBox's Owner/OwnerGroup
+// endpoints (netbox-community/netbox users app), which are not yet covered by the
+// upstream swagger-generated client.
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+
+	"github.com/go-openapi/runtime"
+	"github.com/go-openapi/strfmt"
+)
+
+// UsersOwnersDeleteReader is a Reader for the UsersOwnersDelete structure.
+type UsersOwnersDeleteReader struct {
+	formats strfmt.Registry
+}
+
+// ReadResponse reads a server response into the received o.
+func (o *UsersOwnersDeleteReader) ReadResponse(response runtime.ClientResponse, consumer runtime.Consumer) (interface{}, error) {
+	switch response.Code() {
+	case 204:
+		result := NewUsersOwnersDeleteNoContent()
+		if err := result.readResponse(response, consumer, o.formats); err != nil {
+			return nil, err
+		}
+		return result, nil
+	default:
+		result := NewUsersOwnersDeleteDefault(response.Code())
+		if err := result.readResponse(response, consumer, o.formats); err != nil {
+			return nil, err
+		}
+		if response.Code()/100 == 2 {
+			return result, nil
+		}
+		return nil, result
+	}
+}
+
+// NewUsersOwnersDeleteNoContent creates a UsersOwnersDeleteNoContent with default headers values
+func NewUsersOwnersDeleteNoContent() *UsersOwnersDeleteNoContent {
+	return &UsersOwnersDeleteNoContent{}
+}
+
+/*
+UsersOwnersDeleteNoContent describes a response with status code 204, with default header values.
+
+UsersOwnersDeleteNoContent users owners delete no content
+*/
+type UsersOwnersDeleteNoContent struct {
+}
+
+// IsSuccess returns true when this users owners delete no content response has a 2xx status code
+func (o *UsersOwnersDeleteNoContent) IsSuccess() bool {
+	return true
+}
+
+// IsRedirect returns true when this users owners delete no content response has a 3xx status code
+func (o *UsersOwnersDeleteNoContent) IsRedirect() bool {
+	return false
+}
+
+// IsClientError returns true when this users owners delete no content response has a 4xx status code
+func (o *UsersOwnersDeleteNoContent) IsClientError() bool {
+	return false
+}
+
+// IsServerError returns true when this users owners delete no content response has a 5xx status code
+func (o *UsersOwnersDeleteNoContent) IsServerError() bool {
+	return false
+}
+
+// IsCode returns true when this users owners delete no content response a status code equal to that given
+func (o *UsersOwnersDeleteNoContent) IsCode(code int) bool {
+	return code == 204
+}
+
+// Code gets the status code for the users owners delete no content response
+func (o *UsersOwnersDeleteNoContent) Code() int {
+	return 204
+}
+
+func (o *UsersOwnersDeleteNoContent) Error() string {
+	return fmt.Sprintf("[DELETE /users/owners/{id}/][%d] usersOwnersDeleteNoContent", 204)
+}
+
+func (o *UsersOwnersDeleteNoContent) String() string {
+	return fmt.Sprintf("[DELETE /users/owners/{id}/][%d] usersOwnersDeleteNoContent", 204)
+}
+
+func (o *UsersOwnersDeleteNoContent) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
+
+	return nil
+}
+
+// NewUsersOwnersDeleteDefault creates a UsersOwnersDeleteDefault with default headers values
+func NewUsersOwnersDeleteDefault(code int) *UsersOwnersDeleteDefault {
+	return &UsersOwnersDeleteDefault{
+		_statusCode: code,
+	}
+}
+
+/*
+UsersOwnersDeleteDefault describes a response with status code -1, with default header values.
+
+UsersOwnersDeleteDefault users owners delete default
+*/
+type UsersOwnersDeleteDefault struct {
+	_statusCode int
+
+	Payload interface{}
+}
+
+// IsSuccess returns true when this users owners delete default response has a 2xx status code
+func (o *UsersOwnersDeleteDefault) IsSuccess() bool {
+	return o._statusCode/100 == 2
+}
+
+// IsRedirect returns true when this users owners delete default response has a 3xx status code
+func (o *UsersOwnersDeleteDefault) IsRedirect() bool {
+	return o._statusCode/100 == 3
+}
+
+// IsClientError returns true when this users owners delete default response has a 4xx status code
+func (o *UsersOwnersDeleteDefault) IsClientError() bool {
+	return o._statusCode/100 == 4
+}
+
+// IsServerError returns true when this users owners delete default response has a 5xx status code
+func (o *UsersOwnersDeleteDefault) IsServerError() bool {
+	return o._statusCode/100 == 5
+}
+
+// IsCode returns true when this users owners delete default response a status code equal to that given
+func (o *UsersOwnersDeleteDefault) IsCode(code int) bool {
+	return o._statusCode == code
+}
+
+// Code gets the status code for the users owners delete default response
+func (o *UsersOwnersDeleteDefault) Code() int {
+	return o._statusCode
+}
+
+func (o *UsersOwnersDeleteDefault) Error() string {
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[DELETE /users/owners/{id}/][%d] users_owners_delete default %s", o._statusCode, payload)
+}
+
+func (o *UsersOwnersDeleteDefault) String() string {
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[DELETE /users/owners/{id}/][%d] users_owners_delete default %s", o._statusCode, payload)
+}
+
+func (o *UsersOwnersDeleteDefault) GetPayload() interface{} {
+	return o.Payload
+}
+
+func (o *UsersOwnersDeleteDefault) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
+
+	// response payload
+	if err := consumer.Consume(response.Body(), &o.Payload); err != nil && err != io.EOF {
+		return err
+	}
+
+	return nil
+}

--- a/netbox/client/users/users_owners_list_parameters.go
+++ b/netbox/client/users/users_owners_list_parameters.go
@@ -1,0 +1,981 @@
+// Copyright 2020 The go-netbox Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package users
+
+// This file was manually added to extend the client with NetBox's Owner/OwnerGroup
+// endpoints (netbox-community/netbox users app), which are not yet covered by the
+// upstream swagger-generated client.
+
+import (
+	"context"
+	"net/http"
+	"time"
+
+	"github.com/go-openapi/errors"
+	"github.com/go-openapi/runtime"
+	cr "github.com/go-openapi/runtime/client"
+	"github.com/go-openapi/strfmt"
+	"github.com/go-openapi/swag"
+)
+
+// NewUsersOwnersListParams creates a new UsersOwnersListParams object,
+// with the default timeout for this client.
+//
+// Default values are not hydrated, since defaults are normally applied by the API server side.
+//
+// To enforce default values in parameter, use SetDefaults or WithDefaults.
+func NewUsersOwnersListParams() *UsersOwnersListParams {
+	return &UsersOwnersListParams{
+		timeout: cr.DefaultTimeout,
+	}
+}
+
+// NewUsersOwnersListParamsWithTimeout creates a new UsersOwnersListParams object
+// with the ability to set a timeout on a request.
+func NewUsersOwnersListParamsWithTimeout(timeout time.Duration) *UsersOwnersListParams {
+	return &UsersOwnersListParams{
+		timeout: timeout,
+	}
+}
+
+// NewUsersOwnersListParamsWithContext creates a new UsersOwnersListParams object
+// with the ability to set a context for a request.
+func NewUsersOwnersListParamsWithContext(ctx context.Context) *UsersOwnersListParams {
+	return &UsersOwnersListParams{
+		Context: ctx,
+	}
+}
+
+// NewUsersOwnersListParamsWithHTTPClient creates a new UsersOwnersListParams object
+// with the ability to set a custom HTTPClient for a request.
+func NewUsersOwnersListParamsWithHTTPClient(client *http.Client) *UsersOwnersListParams {
+	return &UsersOwnersListParams{
+		HTTPClient: client,
+	}
+}
+
+/*
+UsersOwnersListParams contains all the parameters to send to the API endpoint
+
+	for the users owners list operation.
+
+	Typically these are written to a http.Request.
+*/
+type UsersOwnersListParams struct {
+
+	// ID.
+	ID *string
+
+	// IDGt.
+	IDGt *string
+
+	// IDGte.
+	IDGte *string
+
+	// IDLt.
+	IDLt *string
+
+	// IDLte.
+	IDLte *string
+
+	// IDn.
+	IDn *string
+
+	// Limit.
+	Limit *int64
+
+	// Name.
+	Name *string
+
+	// NameEmpty.
+	NameEmpty *string
+
+	// NameIc.
+	NameIc *string
+
+	// NameIe.
+	NameIe *string
+
+	// NameIew.
+	NameIew *string
+
+	// NameIsw.
+	NameIsw *string
+
+	// Namen.
+	Namen *string
+
+	// NameNic.
+	NameNic *string
+
+	// NameNie.
+	NameNie *string
+
+	// NameNiew.
+	NameNiew *string
+
+	// NameNisw.
+	NameNisw *string
+
+	// Offset.
+	Offset *int64
+
+	// Ordering.
+	Ordering *string
+
+	// Q.
+	Q *string
+
+	// GroupID.
+	GroupID *string
+
+	// Group.
+	Group *string
+
+	// UserGroupID.
+	UserGroupID *string
+
+	// UserGroup.
+	UserGroup *string
+
+	// UserID.
+	UserID *string
+
+	// User.
+	User *string
+
+	timeout    time.Duration
+	Context    context.Context
+	HTTPClient *http.Client
+}
+
+// WithDefaults hydrates default values in the users owners list params (not the query body).
+//
+// All values with no default are reset to their zero value.
+func (o *UsersOwnersListParams) WithDefaults() *UsersOwnersListParams {
+	o.SetDefaults()
+	return o
+}
+
+// SetDefaults hydrates default values in the users owners list params (not the query body).
+//
+// All values with no default are reset to their zero value.
+func (o *UsersOwnersListParams) SetDefaults() {
+	// no default values defined for this parameter
+}
+
+// WithTimeout adds the timeout to the users owners list params
+func (o *UsersOwnersListParams) WithTimeout(timeout time.Duration) *UsersOwnersListParams {
+	o.SetTimeout(timeout)
+	return o
+}
+
+// SetTimeout adds the timeout to the users owners list params
+func (o *UsersOwnersListParams) SetTimeout(timeout time.Duration) {
+	o.timeout = timeout
+}
+
+// WithContext adds the context to the users owners list params
+func (o *UsersOwnersListParams) WithContext(ctx context.Context) *UsersOwnersListParams {
+	o.SetContext(ctx)
+	return o
+}
+
+// SetContext adds the context to the users owners list params
+func (o *UsersOwnersListParams) SetContext(ctx context.Context) {
+	o.Context = ctx
+}
+
+// WithHTTPClient adds the HTTPClient to the users owners list params
+func (o *UsersOwnersListParams) WithHTTPClient(client *http.Client) *UsersOwnersListParams {
+	o.SetHTTPClient(client)
+	return o
+}
+
+// SetHTTPClient adds the HTTPClient to the users owners list params
+func (o *UsersOwnersListParams) SetHTTPClient(client *http.Client) {
+	o.HTTPClient = client
+}
+
+// WithID adds the iD to the users owners list params
+func (o *UsersOwnersListParams) WithID(iD *string) *UsersOwnersListParams {
+	o.SetID(iD)
+	return o
+}
+
+// SetID adds the iD to the users owners list params
+func (o *UsersOwnersListParams) SetID(iD *string) {
+	o.ID = iD
+}
+
+// WithIDGt adds the iDGt to the users owners list params
+func (o *UsersOwnersListParams) WithIDGt(iDGt *string) *UsersOwnersListParams {
+	o.SetIDGt(iDGt)
+	return o
+}
+
+// SetIDGt adds the iDGt to the users owners list params
+func (o *UsersOwnersListParams) SetIDGt(iDGt *string) {
+	o.IDGt = iDGt
+}
+
+// WithIDGte adds the iDGte to the users owners list params
+func (o *UsersOwnersListParams) WithIDGte(iDGte *string) *UsersOwnersListParams {
+	o.SetIDGte(iDGte)
+	return o
+}
+
+// SetIDGte adds the iDGte to the users owners list params
+func (o *UsersOwnersListParams) SetIDGte(iDGte *string) {
+	o.IDGte = iDGte
+}
+
+// WithIDLt adds the iDLt to the users owners list params
+func (o *UsersOwnersListParams) WithIDLt(iDLt *string) *UsersOwnersListParams {
+	o.SetIDLt(iDLt)
+	return o
+}
+
+// SetIDLt adds the iDLt to the users owners list params
+func (o *UsersOwnersListParams) SetIDLt(iDLt *string) {
+	o.IDLt = iDLt
+}
+
+// WithIDLte adds the iDLte to the users owners list params
+func (o *UsersOwnersListParams) WithIDLte(iDLte *string) *UsersOwnersListParams {
+	o.SetIDLte(iDLte)
+	return o
+}
+
+// SetIDLte adds the iDLte to the users owners list params
+func (o *UsersOwnersListParams) SetIDLte(iDLte *string) {
+	o.IDLte = iDLte
+}
+
+// WithIDn adds the iDn to the users owners list params
+func (o *UsersOwnersListParams) WithIDn(iDn *string) *UsersOwnersListParams {
+	o.SetIDn(iDn)
+	return o
+}
+
+// SetIDn adds the iDn to the users owners list params
+func (o *UsersOwnersListParams) SetIDn(iDn *string) {
+	o.IDn = iDn
+}
+
+// WithLimit adds the limit to the users owners list params
+func (o *UsersOwnersListParams) WithLimit(limit *int64) *UsersOwnersListParams {
+	o.SetLimit(limit)
+	return o
+}
+
+// SetLimit adds the limit to the users owners list params
+func (o *UsersOwnersListParams) SetLimit(limit *int64) {
+	o.Limit = limit
+}
+
+// WithName adds the name to the users owners list params
+func (o *UsersOwnersListParams) WithName(name *string) *UsersOwnersListParams {
+	o.SetName(name)
+	return o
+}
+
+// SetName adds the name to the users owners list params
+func (o *UsersOwnersListParams) SetName(name *string) {
+	o.Name = name
+}
+
+// WithNameEmpty adds the nameEmpty to the users owners list params
+func (o *UsersOwnersListParams) WithNameEmpty(nameEmpty *string) *UsersOwnersListParams {
+	o.SetNameEmpty(nameEmpty)
+	return o
+}
+
+// SetNameEmpty adds the nameEmpty to the users owners list params
+func (o *UsersOwnersListParams) SetNameEmpty(nameEmpty *string) {
+	o.NameEmpty = nameEmpty
+}
+
+// WithNameIc adds the nameIc to the users owners list params
+func (o *UsersOwnersListParams) WithNameIc(nameIc *string) *UsersOwnersListParams {
+	o.SetNameIc(nameIc)
+	return o
+}
+
+// SetNameIc adds the nameIc to the users owners list params
+func (o *UsersOwnersListParams) SetNameIc(nameIc *string) {
+	o.NameIc = nameIc
+}
+
+// WithNameIe adds the nameIe to the users owners list params
+func (o *UsersOwnersListParams) WithNameIe(nameIe *string) *UsersOwnersListParams {
+	o.SetNameIe(nameIe)
+	return o
+}
+
+// SetNameIe adds the nameIe to the users owners list params
+func (o *UsersOwnersListParams) SetNameIe(nameIe *string) {
+	o.NameIe = nameIe
+}
+
+// WithNameIew adds the nameIew to the users owners list params
+func (o *UsersOwnersListParams) WithNameIew(nameIew *string) *UsersOwnersListParams {
+	o.SetNameIew(nameIew)
+	return o
+}
+
+// SetNameIew adds the nameIew to the users owners list params
+func (o *UsersOwnersListParams) SetNameIew(nameIew *string) {
+	o.NameIew = nameIew
+}
+
+// WithNameIsw adds the nameIsw to the users owners list params
+func (o *UsersOwnersListParams) WithNameIsw(nameIsw *string) *UsersOwnersListParams {
+	o.SetNameIsw(nameIsw)
+	return o
+}
+
+// SetNameIsw adds the nameIsw to the users owners list params
+func (o *UsersOwnersListParams) SetNameIsw(nameIsw *string) {
+	o.NameIsw = nameIsw
+}
+
+// WithNamen adds the namen to the users owners list params
+func (o *UsersOwnersListParams) WithNamen(namen *string) *UsersOwnersListParams {
+	o.SetNamen(namen)
+	return o
+}
+
+// SetNamen adds the namen to the users owners list params
+func (o *UsersOwnersListParams) SetNamen(namen *string) {
+	o.Namen = namen
+}
+
+// WithNameNic adds the nameNic to the users owners list params
+func (o *UsersOwnersListParams) WithNameNic(nameNic *string) *UsersOwnersListParams {
+	o.SetNameNic(nameNic)
+	return o
+}
+
+// SetNameNic adds the nameNic to the users owners list params
+func (o *UsersOwnersListParams) SetNameNic(nameNic *string) {
+	o.NameNic = nameNic
+}
+
+// WithNameNie adds the nameNie to the users owners list params
+func (o *UsersOwnersListParams) WithNameNie(nameNie *string) *UsersOwnersListParams {
+	o.SetNameNie(nameNie)
+	return o
+}
+
+// SetNameNie adds the nameNie to the users owners list params
+func (o *UsersOwnersListParams) SetNameNie(nameNie *string) {
+	o.NameNie = nameNie
+}
+
+// WithNameNiew adds the nameNiew to the users owners list params
+func (o *UsersOwnersListParams) WithNameNiew(nameNiew *string) *UsersOwnersListParams {
+	o.SetNameNiew(nameNiew)
+	return o
+}
+
+// SetNameNiew adds the nameNiew to the users owners list params
+func (o *UsersOwnersListParams) SetNameNiew(nameNiew *string) {
+	o.NameNiew = nameNiew
+}
+
+// WithNameNisw adds the nameNisw to the users owners list params
+func (o *UsersOwnersListParams) WithNameNisw(nameNisw *string) *UsersOwnersListParams {
+	o.SetNameNisw(nameNisw)
+	return o
+}
+
+// SetNameNisw adds the nameNisw to the users owners list params
+func (o *UsersOwnersListParams) SetNameNisw(nameNisw *string) {
+	o.NameNisw = nameNisw
+}
+
+// WithOffset adds the offset to the users owners list params
+func (o *UsersOwnersListParams) WithOffset(offset *int64) *UsersOwnersListParams {
+	o.SetOffset(offset)
+	return o
+}
+
+// SetOffset adds the offset to the users owners list params
+func (o *UsersOwnersListParams) SetOffset(offset *int64) {
+	o.Offset = offset
+}
+
+// WithOrdering adds the ordering to the users owners list params
+func (o *UsersOwnersListParams) WithOrdering(ordering *string) *UsersOwnersListParams {
+	o.SetOrdering(ordering)
+	return o
+}
+
+// SetOrdering adds the ordering to the users owners list params
+func (o *UsersOwnersListParams) SetOrdering(ordering *string) {
+	o.Ordering = ordering
+}
+
+// WithQ adds the q to the users owners list params
+func (o *UsersOwnersListParams) WithQ(q *string) *UsersOwnersListParams {
+	o.SetQ(q)
+	return o
+}
+
+// SetQ adds the q to the users owners list params
+func (o *UsersOwnersListParams) SetQ(q *string) {
+	o.Q = q
+}
+
+// WithGroupID adds the groupID to the users owners list params
+func (o *UsersOwnersListParams) WithGroupID(groupID *string) *UsersOwnersListParams {
+	o.SetGroupID(groupID)
+	return o
+}
+
+// SetGroupID adds the groupID to the users owners list params
+func (o *UsersOwnersListParams) SetGroupID(groupID *string) {
+	o.GroupID = groupID
+}
+
+// WithGroup adds the group to the users owners list params
+func (o *UsersOwnersListParams) WithGroup(group *string) *UsersOwnersListParams {
+	o.SetGroup(group)
+	return o
+}
+
+// SetGroup adds the group to the users owners list params
+func (o *UsersOwnersListParams) SetGroup(group *string) {
+	o.Group = group
+}
+
+// WithUserGroupID adds the userGroupID to the users owners list params
+func (o *UsersOwnersListParams) WithUserGroupID(userGroupID *string) *UsersOwnersListParams {
+	o.SetUserGroupID(userGroupID)
+	return o
+}
+
+// SetUserGroupID adds the userGroupID to the users owners list params
+func (o *UsersOwnersListParams) SetUserGroupID(userGroupID *string) {
+	o.UserGroupID = userGroupID
+}
+
+// WithUserGroup adds the userGroup to the users owners list params
+func (o *UsersOwnersListParams) WithUserGroup(userGroup *string) *UsersOwnersListParams {
+	o.SetUserGroup(userGroup)
+	return o
+}
+
+// SetUserGroup adds the userGroup to the users owners list params
+func (o *UsersOwnersListParams) SetUserGroup(userGroup *string) {
+	o.UserGroup = userGroup
+}
+
+// WithUserID adds the userID to the users owners list params
+func (o *UsersOwnersListParams) WithUserID(userID *string) *UsersOwnersListParams {
+	o.SetUserID(userID)
+	return o
+}
+
+// SetUserID adds the userID to the users owners list params
+func (o *UsersOwnersListParams) SetUserID(userID *string) {
+	o.UserID = userID
+}
+
+// WithUser adds the user to the users owners list params
+func (o *UsersOwnersListParams) WithUser(user *string) *UsersOwnersListParams {
+	o.SetUser(user)
+	return o
+}
+
+// SetUser adds the user to the users owners list params
+func (o *UsersOwnersListParams) SetUser(user *string) {
+	o.User = user
+}
+
+// WriteToRequest writes these params to a swagger request
+func (o *UsersOwnersListParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.Registry) error {
+
+	if err := r.SetTimeout(o.timeout); err != nil {
+		return err
+	}
+	var res []error
+
+	if o.ID != nil {
+
+		// query param id
+		var qrID string
+
+		if o.ID != nil {
+			qrID = *o.ID
+		}
+		qID := qrID
+		if qID != "" {
+
+			if err := r.SetQueryParam("id", qID); err != nil {
+				return err
+			}
+		}
+	}
+
+	if o.IDGt != nil {
+
+		// query param id__gt
+		var qrIDGt string
+
+		if o.IDGt != nil {
+			qrIDGt = *o.IDGt
+		}
+		qIDGt := qrIDGt
+		if qIDGt != "" {
+
+			if err := r.SetQueryParam("id__gt", qIDGt); err != nil {
+				return err
+			}
+		}
+	}
+
+	if o.IDGte != nil {
+
+		// query param id__gte
+		var qrIDGte string
+
+		if o.IDGte != nil {
+			qrIDGte = *o.IDGte
+		}
+		qIDGte := qrIDGte
+		if qIDGte != "" {
+
+			if err := r.SetQueryParam("id__gte", qIDGte); err != nil {
+				return err
+			}
+		}
+	}
+
+	if o.IDLt != nil {
+
+		// query param id__lt
+		var qrIDLt string
+
+		if o.IDLt != nil {
+			qrIDLt = *o.IDLt
+		}
+		qIDLt := qrIDLt
+		if qIDLt != "" {
+
+			if err := r.SetQueryParam("id__lt", qIDLt); err != nil {
+				return err
+			}
+		}
+	}
+
+	if o.IDLte != nil {
+
+		// query param id__lte
+		var qrIDLte string
+
+		if o.IDLte != nil {
+			qrIDLte = *o.IDLte
+		}
+		qIDLte := qrIDLte
+		if qIDLte != "" {
+
+			if err := r.SetQueryParam("id__lte", qIDLte); err != nil {
+				return err
+			}
+		}
+	}
+
+	if o.IDn != nil {
+
+		// query param id__n
+		var qrIDn string
+
+		if o.IDn != nil {
+			qrIDn = *o.IDn
+		}
+		qIDn := qrIDn
+		if qIDn != "" {
+
+			if err := r.SetQueryParam("id__n", qIDn); err != nil {
+				return err
+			}
+		}
+	}
+
+	if o.Limit != nil {
+
+		// query param limit
+		var qrLimit int64
+
+		if o.Limit != nil {
+			qrLimit = *o.Limit
+		}
+		qLimit := swag.FormatInt64(qrLimit)
+		if qLimit != "" {
+
+			if err := r.SetQueryParam("limit", qLimit); err != nil {
+				return err
+			}
+		}
+	}
+
+	if o.Name != nil {
+
+		// query param name
+		var qrName string
+
+		if o.Name != nil {
+			qrName = *o.Name
+		}
+		qName := qrName
+		if qName != "" {
+
+			if err := r.SetQueryParam("name", qName); err != nil {
+				return err
+			}
+		}
+	}
+
+	if o.NameEmpty != nil {
+
+		// query param name__empty
+		var qrNameEmpty string
+
+		if o.NameEmpty != nil {
+			qrNameEmpty = *o.NameEmpty
+		}
+		qNameEmpty := qrNameEmpty
+		if qNameEmpty != "" {
+
+			if err := r.SetQueryParam("name__empty", qNameEmpty); err != nil {
+				return err
+			}
+		}
+	}
+
+	if o.NameIc != nil {
+
+		// query param name__ic
+		var qrNameIc string
+
+		if o.NameIc != nil {
+			qrNameIc = *o.NameIc
+		}
+		qNameIc := qrNameIc
+		if qNameIc != "" {
+
+			if err := r.SetQueryParam("name__ic", qNameIc); err != nil {
+				return err
+			}
+		}
+	}
+
+	if o.NameIe != nil {
+
+		// query param name__ie
+		var qrNameIe string
+
+		if o.NameIe != nil {
+			qrNameIe = *o.NameIe
+		}
+		qNameIe := qrNameIe
+		if qNameIe != "" {
+
+			if err := r.SetQueryParam("name__ie", qNameIe); err != nil {
+				return err
+			}
+		}
+	}
+
+	if o.NameIew != nil {
+
+		// query param name__iew
+		var qrNameIew string
+
+		if o.NameIew != nil {
+			qrNameIew = *o.NameIew
+		}
+		qNameIew := qrNameIew
+		if qNameIew != "" {
+
+			if err := r.SetQueryParam("name__iew", qNameIew); err != nil {
+				return err
+			}
+		}
+	}
+
+	if o.NameIsw != nil {
+
+		// query param name__isw
+		var qrNameIsw string
+
+		if o.NameIsw != nil {
+			qrNameIsw = *o.NameIsw
+		}
+		qNameIsw := qrNameIsw
+		if qNameIsw != "" {
+
+			if err := r.SetQueryParam("name__isw", qNameIsw); err != nil {
+				return err
+			}
+		}
+	}
+
+	if o.Namen != nil {
+
+		// query param name__n
+		var qrNamen string
+
+		if o.Namen != nil {
+			qrNamen = *o.Namen
+		}
+		qNamen := qrNamen
+		if qNamen != "" {
+
+			if err := r.SetQueryParam("name__n", qNamen); err != nil {
+				return err
+			}
+		}
+	}
+
+	if o.NameNic != nil {
+
+		// query param name__nic
+		var qrNameNic string
+
+		if o.NameNic != nil {
+			qrNameNic = *o.NameNic
+		}
+		qNameNic := qrNameNic
+		if qNameNic != "" {
+
+			if err := r.SetQueryParam("name__nic", qNameNic); err != nil {
+				return err
+			}
+		}
+	}
+
+	if o.NameNie != nil {
+
+		// query param name__nie
+		var qrNameNie string
+
+		if o.NameNie != nil {
+			qrNameNie = *o.NameNie
+		}
+		qNameNie := qrNameNie
+		if qNameNie != "" {
+
+			if err := r.SetQueryParam("name__nie", qNameNie); err != nil {
+				return err
+			}
+		}
+	}
+
+	if o.NameNiew != nil {
+
+		// query param name__niew
+		var qrNameNiew string
+
+		if o.NameNiew != nil {
+			qrNameNiew = *o.NameNiew
+		}
+		qNameNiew := qrNameNiew
+		if qNameNiew != "" {
+
+			if err := r.SetQueryParam("name__niew", qNameNiew); err != nil {
+				return err
+			}
+		}
+	}
+
+	if o.NameNisw != nil {
+
+		// query param name__nisw
+		var qrNameNisw string
+
+		if o.NameNisw != nil {
+			qrNameNisw = *o.NameNisw
+		}
+		qNameNisw := qrNameNisw
+		if qNameNisw != "" {
+
+			if err := r.SetQueryParam("name__nisw", qNameNisw); err != nil {
+				return err
+			}
+		}
+	}
+
+	if o.Offset != nil {
+
+		// query param offset
+		var qrOffset int64
+
+		if o.Offset != nil {
+			qrOffset = *o.Offset
+		}
+		qOffset := swag.FormatInt64(qrOffset)
+		if qOffset != "" {
+
+			if err := r.SetQueryParam("offset", qOffset); err != nil {
+				return err
+			}
+		}
+	}
+
+	if o.Ordering != nil {
+
+		// query param ordering
+		var qrOrdering string
+
+		if o.Ordering != nil {
+			qrOrdering = *o.Ordering
+		}
+		qOrdering := qrOrdering
+		if qOrdering != "" {
+
+			if err := r.SetQueryParam("ordering", qOrdering); err != nil {
+				return err
+			}
+		}
+	}
+
+	if o.Q != nil {
+
+		// query param q
+		var qrQ string
+
+		if o.Q != nil {
+			qrQ = *o.Q
+		}
+		qQ := qrQ
+		if qQ != "" {
+
+			if err := r.SetQueryParam("q", qQ); err != nil {
+				return err
+			}
+		}
+	}
+
+	if o.GroupID != nil {
+
+		// query param group_id
+		var qrGroupID string
+
+		if o.GroupID != nil {
+			qrGroupID = *o.GroupID
+		}
+		qGroupID := qrGroupID
+		if qGroupID != "" {
+
+			if err := r.SetQueryParam("group_id", qGroupID); err != nil {
+				return err
+			}
+		}
+	}
+
+	if o.Group != nil {
+
+		// query param group
+		var qrGroup string
+
+		if o.Group != nil {
+			qrGroup = *o.Group
+		}
+		qGroup := qrGroup
+		if qGroup != "" {
+
+			if err := r.SetQueryParam("group", qGroup); err != nil {
+				return err
+			}
+		}
+	}
+
+	if o.UserGroupID != nil {
+
+		// query param user_group_id
+		var qrUserGroupID string
+
+		if o.UserGroupID != nil {
+			qrUserGroupID = *o.UserGroupID
+		}
+		qUserGroupID := qrUserGroupID
+		if qUserGroupID != "" {
+
+			if err := r.SetQueryParam("user_group_id", qUserGroupID); err != nil {
+				return err
+			}
+		}
+	}
+
+	if o.UserGroup != nil {
+
+		// query param user_group
+		var qrUserGroup string
+
+		if o.UserGroup != nil {
+			qrUserGroup = *o.UserGroup
+		}
+		qUserGroup := qrUserGroup
+		if qUserGroup != "" {
+
+			if err := r.SetQueryParam("user_group", qUserGroup); err != nil {
+				return err
+			}
+		}
+	}
+
+	if o.UserID != nil {
+
+		// query param user_id
+		var qrUserID string
+
+		if o.UserID != nil {
+			qrUserID = *o.UserID
+		}
+		qUserID := qrUserID
+		if qUserID != "" {
+
+			if err := r.SetQueryParam("user_id", qUserID); err != nil {
+				return err
+			}
+		}
+	}
+
+	if o.User != nil {
+
+		// query param user
+		var qrUser string
+
+		if o.User != nil {
+			qrUser = *o.User
+		}
+		qUser := qrUser
+		if qUser != "" {
+
+			if err := r.SetQueryParam("user", qUser); err != nil {
+				return err
+			}
+		}
+	}
+
+	if len(res) > 0 {
+		return errors.CompositeValidationError(res...)
+	}
+	return nil
+}

--- a/netbox/client/users/users_owners_list_responses.go
+++ b/netbox/client/users/users_owners_list_responses.go
@@ -1,0 +1,370 @@
+// Copyright 2020 The go-netbox Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package users
+
+// This file was manually added to extend the client with NetBox's Owner/OwnerGroup
+// endpoints (netbox-community/netbox users app), which are not yet covered by the
+// upstream swagger-generated client.
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"strconv"
+
+	"github.com/go-openapi/errors"
+	"github.com/go-openapi/runtime"
+	"github.com/go-openapi/strfmt"
+	"github.com/go-openapi/swag"
+	"github.com/go-openapi/validate"
+
+	"github.com/fbreckle/go-netbox/netbox/models"
+)
+
+// UsersOwnersListReader is a Reader for the UsersOwnersList structure.
+type UsersOwnersListReader struct {
+	formats strfmt.Registry
+}
+
+// ReadResponse reads a server response into the received o.
+func (o *UsersOwnersListReader) ReadResponse(response runtime.ClientResponse, consumer runtime.Consumer) (interface{}, error) {
+	switch response.Code() {
+	case 200:
+		result := NewUsersOwnersListOK()
+		if err := result.readResponse(response, consumer, o.formats); err != nil {
+			return nil, err
+		}
+		return result, nil
+	default:
+		result := NewUsersOwnersListDefault(response.Code())
+		if err := result.readResponse(response, consumer, o.formats); err != nil {
+			return nil, err
+		}
+		if response.Code()/100 == 2 {
+			return result, nil
+		}
+		return nil, result
+	}
+}
+
+// NewUsersOwnersListOK creates a UsersOwnersListOK with default headers values
+func NewUsersOwnersListOK() *UsersOwnersListOK {
+	return &UsersOwnersListOK{}
+}
+
+/*
+UsersOwnersListOK describes a response with status code 200, with default header values.
+
+UsersOwnersListOK users owners list o k
+*/
+type UsersOwnersListOK struct {
+	Payload *UsersOwnersListOKBody
+}
+
+// IsSuccess returns true when this users owners list o k response has a 2xx status code
+func (o *UsersOwnersListOK) IsSuccess() bool {
+	return true
+}
+
+// IsRedirect returns true when this users owners list o k response has a 3xx status code
+func (o *UsersOwnersListOK) IsRedirect() bool {
+	return false
+}
+
+// IsClientError returns true when this users owners list o k response has a 4xx status code
+func (o *UsersOwnersListOK) IsClientError() bool {
+	return false
+}
+
+// IsServerError returns true when this users owners list o k response has a 5xx status code
+func (o *UsersOwnersListOK) IsServerError() bool {
+	return false
+}
+
+// IsCode returns true when this users owners list o k response a status code equal to that given
+func (o *UsersOwnersListOK) IsCode(code int) bool {
+	return code == 200
+}
+
+// Code gets the status code for the users owners list o k response
+func (o *UsersOwnersListOK) Code() int {
+	return 200
+}
+
+func (o *UsersOwnersListOK) Error() string {
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /users/owners/][%d] usersOwnersListOK %s", 200, payload)
+}
+
+func (o *UsersOwnersListOK) String() string {
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /users/owners/][%d] usersOwnersListOK %s", 200, payload)
+}
+
+func (o *UsersOwnersListOK) GetPayload() *UsersOwnersListOKBody {
+	return o.Payload
+}
+
+func (o *UsersOwnersListOK) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
+
+	o.Payload = new(UsersOwnersListOKBody)
+
+	// response payload
+	if err := consumer.Consume(response.Body(), o.Payload); err != nil && err != io.EOF {
+		return err
+	}
+
+	return nil
+}
+
+// NewUsersOwnersListDefault creates a UsersOwnersListDefault with default headers values
+func NewUsersOwnersListDefault(code int) *UsersOwnersListDefault {
+	return &UsersOwnersListDefault{
+		_statusCode: code,
+	}
+}
+
+/*
+UsersOwnersListDefault describes a response with status code -1, with default header values.
+
+UsersOwnersListDefault users owners list default
+*/
+type UsersOwnersListDefault struct {
+	_statusCode int
+
+	Payload interface{}
+}
+
+// IsSuccess returns true when this users owners list default response has a 2xx status code
+func (o *UsersOwnersListDefault) IsSuccess() bool {
+	return o._statusCode/100 == 2
+}
+
+// IsRedirect returns true when this users owners list default response has a 3xx status code
+func (o *UsersOwnersListDefault) IsRedirect() bool {
+	return o._statusCode/100 == 3
+}
+
+// IsClientError returns true when this users owners list default response has a 4xx status code
+func (o *UsersOwnersListDefault) IsClientError() bool {
+	return o._statusCode/100 == 4
+}
+
+// IsServerError returns true when this users owners list default response has a 5xx status code
+func (o *UsersOwnersListDefault) IsServerError() bool {
+	return o._statusCode/100 == 5
+}
+
+// IsCode returns true when this users owners list default response a status code equal to that given
+func (o *UsersOwnersListDefault) IsCode(code int) bool {
+	return o._statusCode == code
+}
+
+// Code gets the status code for the users owners list default response
+func (o *UsersOwnersListDefault) Code() int {
+	return o._statusCode
+}
+
+func (o *UsersOwnersListDefault) Error() string {
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /users/owners/][%d] users_owners_list default %s", o._statusCode, payload)
+}
+
+func (o *UsersOwnersListDefault) String() string {
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /users/owners/][%d] users_owners_list default %s", o._statusCode, payload)
+}
+
+func (o *UsersOwnersListDefault) GetPayload() interface{} {
+	return o.Payload
+}
+
+func (o *UsersOwnersListDefault) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
+
+	// response payload
+	if err := consumer.Consume(response.Body(), &o.Payload); err != nil && err != io.EOF {
+		return err
+	}
+
+	return nil
+}
+
+/*
+UsersOwnersListOKBody users owners list o k body
+swagger:model UsersOwnersListOKBody
+*/
+type UsersOwnersListOKBody struct {
+
+	// count
+	// Required: true
+	Count *int64 `json:"count"`
+
+	// next
+	// Format: uri
+	Next *strfmt.URI `json:"next,omitempty"`
+
+	// previous
+	// Format: uri
+	Previous *strfmt.URI `json:"previous,omitempty"`
+
+	// results
+	// Required: true
+	Results []*models.Owner `json:"results"`
+}
+
+// Validate validates this usersOwnersList o k body
+func (o *UsersOwnersListOKBody) Validate(formats strfmt.Registry) error {
+	var res []error
+
+	if err := o.validateCount(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := o.validateNext(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := o.validatePrevious(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := o.validateResults(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if len(res) > 0 {
+		return errors.CompositeValidationError(res...)
+	}
+	return nil
+}
+
+func (o *UsersOwnersListOKBody) validateCount(formats strfmt.Registry) error {
+
+	if err := validate.Required("usersOwnersListOK"+"."+"count", "body", o.Count); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (o *UsersOwnersListOKBody) validateNext(formats strfmt.Registry) error {
+	if swag.IsZero(o.Next) { // not required
+		return nil
+	}
+
+	if err := validate.FormatOf("usersOwnersListOK"+"."+"next", "body", "uri", o.Next.String(), formats); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (o *UsersOwnersListOKBody) validatePrevious(formats strfmt.Registry) error {
+	if swag.IsZero(o.Previous) { // not required
+		return nil
+	}
+
+	if err := validate.FormatOf("usersOwnersListOK"+"."+"previous", "body", "uri", o.Previous.String(), formats); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (o *UsersOwnersListOKBody) validateResults(formats strfmt.Registry) error {
+
+	if err := validate.Required("usersOwnersListOK"+"."+"results", "body", o.Results); err != nil {
+		return err
+	}
+
+	for i := 0; i < len(o.Results); i++ {
+		if swag.IsZero(o.Results[i]) { // not required
+			continue
+		}
+
+		if o.Results[i] != nil {
+			if err := o.Results[i].Validate(formats); err != nil {
+				if ve, ok := err.(*errors.Validation); ok {
+					return ve.ValidateName("usersOwnersListOK" + "." + "results" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("usersOwnersListOK" + "." + "results" + "." + strconv.Itoa(i))
+				}
+				return err
+			}
+		}
+
+	}
+
+	return nil
+}
+
+// ContextValidate validate this usersOwnersList o k body based on the context it is used
+func (o *UsersOwnersListOKBody) ContextValidate(ctx context.Context, formats strfmt.Registry) error {
+	var res []error
+
+	if err := o.contextValidateResults(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
+	if len(res) > 0 {
+		return errors.CompositeValidationError(res...)
+	}
+	return nil
+}
+
+func (o *UsersOwnersListOKBody) contextValidateResults(ctx context.Context, formats strfmt.Registry) error {
+
+	for i := 0; i < len(o.Results); i++ {
+
+		if o.Results[i] != nil {
+
+			if swag.IsZero(o.Results[i]) { // not required
+				return nil
+			}
+
+			if err := o.Results[i].ContextValidate(ctx, formats); err != nil {
+				if ve, ok := err.(*errors.Validation); ok {
+					return ve.ValidateName("usersOwnersListOK" + "." + "results" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("usersOwnersListOK" + "." + "results" + "." + strconv.Itoa(i))
+				}
+				return err
+			}
+		}
+
+	}
+
+	return nil
+}
+
+// MarshalBinary interface implementation
+func (o *UsersOwnersListOKBody) MarshalBinary() ([]byte, error) {
+	if o == nil {
+		return nil, nil
+	}
+	return swag.WriteJSON(o)
+}
+
+// UnmarshalBinary interface implementation
+func (o *UsersOwnersListOKBody) UnmarshalBinary(b []byte) error {
+	var res UsersOwnersListOKBody
+	if err := swag.ReadJSON(b, &res); err != nil {
+		return err
+	}
+	*o = res
+	return nil
+}

--- a/netbox/client/users/users_owners_partial_update_parameters.go
+++ b/netbox/client/users/users_owners_partial_update_parameters.go
@@ -1,0 +1,187 @@
+// Copyright 2020 The go-netbox Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package users
+
+// This file was manually added to extend the client with NetBox's Owner/OwnerGroup
+// endpoints (netbox-community/netbox users app), which are not yet covered by the
+// upstream swagger-generated client.
+
+import (
+	"context"
+	"net/http"
+	"time"
+
+	"github.com/go-openapi/errors"
+	"github.com/go-openapi/runtime"
+	cr "github.com/go-openapi/runtime/client"
+	"github.com/go-openapi/strfmt"
+	"github.com/go-openapi/swag"
+
+	"github.com/fbreckle/go-netbox/netbox/models"
+)
+
+// NewUsersOwnersPartialUpdateParams creates a new UsersOwnersPartialUpdateParams object,
+// with the default timeout for this client.
+//
+// Default values are not hydrated, since defaults are normally applied by the API server side.
+//
+// To enforce default values in parameter, use SetDefaults or WithDefaults.
+func NewUsersOwnersPartialUpdateParams() *UsersOwnersPartialUpdateParams {
+	return &UsersOwnersPartialUpdateParams{
+		timeout: cr.DefaultTimeout,
+	}
+}
+
+// NewUsersOwnersPartialUpdateParamsWithTimeout creates a new UsersOwnersPartialUpdateParams object
+// with the ability to set a timeout on a request.
+func NewUsersOwnersPartialUpdateParamsWithTimeout(timeout time.Duration) *UsersOwnersPartialUpdateParams {
+	return &UsersOwnersPartialUpdateParams{
+		timeout: timeout,
+	}
+}
+
+// NewUsersOwnersPartialUpdateParamsWithContext creates a new UsersOwnersPartialUpdateParams object
+// with the ability to set a context for a request.
+func NewUsersOwnersPartialUpdateParamsWithContext(ctx context.Context) *UsersOwnersPartialUpdateParams {
+	return &UsersOwnersPartialUpdateParams{
+		Context: ctx,
+	}
+}
+
+// NewUsersOwnersPartialUpdateParamsWithHTTPClient creates a new UsersOwnersPartialUpdateParams object
+// with the ability to set a custom HTTPClient for a request.
+func NewUsersOwnersPartialUpdateParamsWithHTTPClient(client *http.Client) *UsersOwnersPartialUpdateParams {
+	return &UsersOwnersPartialUpdateParams{
+		HTTPClient: client,
+	}
+}
+
+/*
+UsersOwnersPartialUpdateParams contains all the parameters to send to the API endpoint
+
+	for the users owners partial update operation.
+
+	Typically these are written to a http.Request.
+*/
+type UsersOwnersPartialUpdateParams struct {
+
+	// Data.
+	Data *models.WritableOwner
+
+	/* ID.
+
+	   A unique integer value identifying this owner.
+	*/
+	ID int64
+
+	timeout    time.Duration
+	Context    context.Context
+	HTTPClient *http.Client
+}
+
+// WithDefaults hydrates default values in the users owners partial update params (not the query body).
+//
+// All values with no default are reset to their zero value.
+func (o *UsersOwnersPartialUpdateParams) WithDefaults() *UsersOwnersPartialUpdateParams {
+	o.SetDefaults()
+	return o
+}
+
+// SetDefaults hydrates default values in the users owners partial update params (not the query body).
+//
+// All values with no default are reset to their zero value.
+func (o *UsersOwnersPartialUpdateParams) SetDefaults() {
+	// no default values defined for this parameter
+}
+
+// WithTimeout adds the timeout to the users owners partial update params
+func (o *UsersOwnersPartialUpdateParams) WithTimeout(timeout time.Duration) *UsersOwnersPartialUpdateParams {
+	o.SetTimeout(timeout)
+	return o
+}
+
+// SetTimeout adds the timeout to the users owners partial update params
+func (o *UsersOwnersPartialUpdateParams) SetTimeout(timeout time.Duration) {
+	o.timeout = timeout
+}
+
+// WithContext adds the context to the users owners partial update params
+func (o *UsersOwnersPartialUpdateParams) WithContext(ctx context.Context) *UsersOwnersPartialUpdateParams {
+	o.SetContext(ctx)
+	return o
+}
+
+// SetContext adds the context to the users owners partial update params
+func (o *UsersOwnersPartialUpdateParams) SetContext(ctx context.Context) {
+	o.Context = ctx
+}
+
+// WithHTTPClient adds the HTTPClient to the users owners partial update params
+func (o *UsersOwnersPartialUpdateParams) WithHTTPClient(client *http.Client) *UsersOwnersPartialUpdateParams {
+	o.SetHTTPClient(client)
+	return o
+}
+
+// SetHTTPClient adds the HTTPClient to the users owners partial update params
+func (o *UsersOwnersPartialUpdateParams) SetHTTPClient(client *http.Client) {
+	o.HTTPClient = client
+}
+
+// WithData adds the data to the users owners partial update params
+func (o *UsersOwnersPartialUpdateParams) WithData(data *models.WritableOwner) *UsersOwnersPartialUpdateParams {
+	o.SetData(data)
+	return o
+}
+
+// SetData adds the data to the users owners partial update params
+func (o *UsersOwnersPartialUpdateParams) SetData(data *models.WritableOwner) {
+	o.Data = data
+}
+
+// WithID adds the id to the users owners partial update params
+func (o *UsersOwnersPartialUpdateParams) WithID(id int64) *UsersOwnersPartialUpdateParams {
+	o.SetID(id)
+	return o
+}
+
+// SetID adds the id to the users owners partial update params
+func (o *UsersOwnersPartialUpdateParams) SetID(id int64) {
+	o.ID = id
+}
+
+// WriteToRequest writes these params to a swagger request
+func (o *UsersOwnersPartialUpdateParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.Registry) error {
+
+	if err := r.SetTimeout(o.timeout); err != nil {
+		return err
+	}
+	var res []error
+	if o.Data != nil {
+		if err := r.SetBodyParam(o.Data); err != nil {
+			return err
+		}
+	}
+
+	// path param id
+	if err := r.SetPathParam("id", swag.FormatInt64(o.ID)); err != nil {
+		return err
+	}
+
+	if len(res) > 0 {
+		return errors.CompositeValidationError(res...)
+	}
+	return nil
+}

--- a/netbox/client/users/users_owners_partial_update_responses.go
+++ b/netbox/client/users/users_owners_partial_update_responses.go
@@ -67,7 +67,7 @@ UsersOwnersPartialUpdateOK describes a response with status code 200, with defau
 UsersOwnersPartialUpdateOK users owners partial update o k
 */
 type UsersOwnersPartialUpdateOK struct {
-	Payload *models.WritableOwner
+	Payload *models.Owner
 }
 
 // IsSuccess returns true when this users owners partial update o k response has a 2xx status code
@@ -110,13 +110,13 @@ func (o *UsersOwnersPartialUpdateOK) String() string {
 	return fmt.Sprintf("[PATCH /users/owners/{id}/][%d] usersOwnersPartialUpdateOK %s", 200, payload)
 }
 
-func (o *UsersOwnersPartialUpdateOK) GetPayload() *models.WritableOwner {
+func (o *UsersOwnersPartialUpdateOK) GetPayload() *models.Owner {
 	return o.Payload
 }
 
 func (o *UsersOwnersPartialUpdateOK) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
 
-	o.Payload = new(models.WritableOwner)
+	o.Payload = new(models.Owner)
 
 	// response payload
 	if err := consumer.Consume(response.Body(), o.Payload); err != nil && err != io.EOF {

--- a/netbox/client/users/users_owners_partial_update_responses.go
+++ b/netbox/client/users/users_owners_partial_update_responses.go
@@ -1,0 +1,199 @@
+// Copyright 2020 The go-netbox Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package users
+
+// This file was manually added to extend the client with NetBox's Owner/OwnerGroup
+// endpoints (netbox-community/netbox users app), which are not yet covered by the
+// upstream swagger-generated client.
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+
+	"github.com/go-openapi/runtime"
+	"github.com/go-openapi/strfmt"
+
+	"github.com/fbreckle/go-netbox/netbox/models"
+)
+
+// UsersOwnersPartialUpdateReader is a Reader for the UsersOwnersPartialUpdate structure.
+type UsersOwnersPartialUpdateReader struct {
+	formats strfmt.Registry
+}
+
+// ReadResponse reads a server response into the received o.
+func (o *UsersOwnersPartialUpdateReader) ReadResponse(response runtime.ClientResponse, consumer runtime.Consumer) (interface{}, error) {
+	switch response.Code() {
+	case 200:
+		result := NewUsersOwnersPartialUpdateOK()
+		if err := result.readResponse(response, consumer, o.formats); err != nil {
+			return nil, err
+		}
+		return result, nil
+	default:
+		result := NewUsersOwnersPartialUpdateDefault(response.Code())
+		if err := result.readResponse(response, consumer, o.formats); err != nil {
+			return nil, err
+		}
+		if response.Code()/100 == 2 {
+			return result, nil
+		}
+		return nil, result
+	}
+}
+
+// NewUsersOwnersPartialUpdateOK creates a UsersOwnersPartialUpdateOK with default headers values
+func NewUsersOwnersPartialUpdateOK() *UsersOwnersPartialUpdateOK {
+	return &UsersOwnersPartialUpdateOK{}
+}
+
+/*
+UsersOwnersPartialUpdateOK describes a response with status code 200, with default header values.
+
+UsersOwnersPartialUpdateOK users owners partial update o k
+*/
+type UsersOwnersPartialUpdateOK struct {
+	Payload *models.WritableOwner
+}
+
+// IsSuccess returns true when this users owners partial update o k response has a 2xx status code
+func (o *UsersOwnersPartialUpdateOK) IsSuccess() bool {
+	return true
+}
+
+// IsRedirect returns true when this users owners partial update o k response has a 3xx status code
+func (o *UsersOwnersPartialUpdateOK) IsRedirect() bool {
+	return false
+}
+
+// IsClientError returns true when this users owners partial update o k response has a 4xx status code
+func (o *UsersOwnersPartialUpdateOK) IsClientError() bool {
+	return false
+}
+
+// IsServerError returns true when this users owners partial update o k response has a 5xx status code
+func (o *UsersOwnersPartialUpdateOK) IsServerError() bool {
+	return false
+}
+
+// IsCode returns true when this users owners partial update o k response a status code equal to that given
+func (o *UsersOwnersPartialUpdateOK) IsCode(code int) bool {
+	return code == 200
+}
+
+// Code gets the status code for the users owners partial update o k response
+func (o *UsersOwnersPartialUpdateOK) Code() int {
+	return 200
+}
+
+func (o *UsersOwnersPartialUpdateOK) Error() string {
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[PATCH /users/owners/{id}/][%d] usersOwnersPartialUpdateOK %s", 200, payload)
+}
+
+func (o *UsersOwnersPartialUpdateOK) String() string {
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[PATCH /users/owners/{id}/][%d] usersOwnersPartialUpdateOK %s", 200, payload)
+}
+
+func (o *UsersOwnersPartialUpdateOK) GetPayload() *models.WritableOwner {
+	return o.Payload
+}
+
+func (o *UsersOwnersPartialUpdateOK) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
+
+	o.Payload = new(models.WritableOwner)
+
+	// response payload
+	if err := consumer.Consume(response.Body(), o.Payload); err != nil && err != io.EOF {
+		return err
+	}
+
+	return nil
+}
+
+// NewUsersOwnersPartialUpdateDefault creates a UsersOwnersPartialUpdateDefault with default headers values
+func NewUsersOwnersPartialUpdateDefault(code int) *UsersOwnersPartialUpdateDefault {
+	return &UsersOwnersPartialUpdateDefault{
+		_statusCode: code,
+	}
+}
+
+/*
+UsersOwnersPartialUpdateDefault describes a response with status code -1, with default header values.
+
+UsersOwnersPartialUpdateDefault users owners partial update default
+*/
+type UsersOwnersPartialUpdateDefault struct {
+	_statusCode int
+
+	Payload interface{}
+}
+
+// IsSuccess returns true when this users owners partial update default response has a 2xx status code
+func (o *UsersOwnersPartialUpdateDefault) IsSuccess() bool {
+	return o._statusCode/100 == 2
+}
+
+// IsRedirect returns true when this users owners partial update default response has a 3xx status code
+func (o *UsersOwnersPartialUpdateDefault) IsRedirect() bool {
+	return o._statusCode/100 == 3
+}
+
+// IsClientError returns true when this users owners partial update default response has a 4xx status code
+func (o *UsersOwnersPartialUpdateDefault) IsClientError() bool {
+	return o._statusCode/100 == 4
+}
+
+// IsServerError returns true when this users owners partial update default response has a 5xx status code
+func (o *UsersOwnersPartialUpdateDefault) IsServerError() bool {
+	return o._statusCode/100 == 5
+}
+
+// IsCode returns true when this users owners partial update default response a status code equal to that given
+func (o *UsersOwnersPartialUpdateDefault) IsCode(code int) bool {
+	return o._statusCode == code
+}
+
+// Code gets the status code for the users owners partial update default response
+func (o *UsersOwnersPartialUpdateDefault) Code() int {
+	return o._statusCode
+}
+
+func (o *UsersOwnersPartialUpdateDefault) Error() string {
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[PATCH /users/owners/{id}/][%d] users_owners_partial_update default %s", o._statusCode, payload)
+}
+
+func (o *UsersOwnersPartialUpdateDefault) String() string {
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[PATCH /users/owners/{id}/][%d] users_owners_partial_update default %s", o._statusCode, payload)
+}
+
+func (o *UsersOwnersPartialUpdateDefault) GetPayload() interface{} {
+	return o.Payload
+}
+
+func (o *UsersOwnersPartialUpdateDefault) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
+
+	// response payload
+	if err := consumer.Consume(response.Body(), &o.Payload); err != nil && err != io.EOF {
+		return err
+	}
+
+	return nil
+}

--- a/netbox/client/users/users_owners_read_parameters.go
+++ b/netbox/client/users/users_owners_read_parameters.go
@@ -1,0 +1,166 @@
+// Copyright 2020 The go-netbox Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package users
+
+// This file was manually added to extend the client with NetBox's Owner/OwnerGroup
+// endpoints (netbox-community/netbox users app), which are not yet covered by the
+// upstream swagger-generated client.
+
+import (
+	"context"
+	"net/http"
+	"time"
+
+	"github.com/go-openapi/errors"
+	"github.com/go-openapi/runtime"
+	cr "github.com/go-openapi/runtime/client"
+	"github.com/go-openapi/strfmt"
+	"github.com/go-openapi/swag"
+)
+
+// NewUsersOwnersReadParams creates a new UsersOwnersReadParams object,
+// with the default timeout for this client.
+//
+// Default values are not hydrated, since defaults are normally applied by the API server side.
+//
+// To enforce default values in parameter, use SetDefaults or WithDefaults.
+func NewUsersOwnersReadParams() *UsersOwnersReadParams {
+	return &UsersOwnersReadParams{
+		timeout: cr.DefaultTimeout,
+	}
+}
+
+// NewUsersOwnersReadParamsWithTimeout creates a new UsersOwnersReadParams object
+// with the ability to set a timeout on a request.
+func NewUsersOwnersReadParamsWithTimeout(timeout time.Duration) *UsersOwnersReadParams {
+	return &UsersOwnersReadParams{
+		timeout: timeout,
+	}
+}
+
+// NewUsersOwnersReadParamsWithContext creates a new UsersOwnersReadParams object
+// with the ability to set a context for a request.
+func NewUsersOwnersReadParamsWithContext(ctx context.Context) *UsersOwnersReadParams {
+	return &UsersOwnersReadParams{
+		Context: ctx,
+	}
+}
+
+// NewUsersOwnersReadParamsWithHTTPClient creates a new UsersOwnersReadParams object
+// with the ability to set a custom HTTPClient for a request.
+func NewUsersOwnersReadParamsWithHTTPClient(client *http.Client) *UsersOwnersReadParams {
+	return &UsersOwnersReadParams{
+		HTTPClient: client,
+	}
+}
+
+/*
+UsersOwnersReadParams contains all the parameters to send to the API endpoint
+
+	for the users owners read operation.
+
+	Typically these are written to a http.Request.
+*/
+type UsersOwnersReadParams struct {
+
+	/* ID.
+
+	   A unique integer value identifying this owner.
+	*/
+	ID int64
+
+	timeout    time.Duration
+	Context    context.Context
+	HTTPClient *http.Client
+}
+
+// WithDefaults hydrates default values in the users owners read params (not the query body).
+//
+// All values with no default are reset to their zero value.
+func (o *UsersOwnersReadParams) WithDefaults() *UsersOwnersReadParams {
+	o.SetDefaults()
+	return o
+}
+
+// SetDefaults hydrates default values in the users owners read params (not the query body).
+//
+// All values with no default are reset to their zero value.
+func (o *UsersOwnersReadParams) SetDefaults() {
+	// no default values defined for this parameter
+}
+
+// WithTimeout adds the timeout to the users owners read params
+func (o *UsersOwnersReadParams) WithTimeout(timeout time.Duration) *UsersOwnersReadParams {
+	o.SetTimeout(timeout)
+	return o
+}
+
+// SetTimeout adds the timeout to the users owners read params
+func (o *UsersOwnersReadParams) SetTimeout(timeout time.Duration) {
+	o.timeout = timeout
+}
+
+// WithContext adds the context to the users owners read params
+func (o *UsersOwnersReadParams) WithContext(ctx context.Context) *UsersOwnersReadParams {
+	o.SetContext(ctx)
+	return o
+}
+
+// SetContext adds the context to the users owners read params
+func (o *UsersOwnersReadParams) SetContext(ctx context.Context) {
+	o.Context = ctx
+}
+
+// WithHTTPClient adds the HTTPClient to the users owners read params
+func (o *UsersOwnersReadParams) WithHTTPClient(client *http.Client) *UsersOwnersReadParams {
+	o.SetHTTPClient(client)
+	return o
+}
+
+// SetHTTPClient adds the HTTPClient to the users owners read params
+func (o *UsersOwnersReadParams) SetHTTPClient(client *http.Client) {
+	o.HTTPClient = client
+}
+
+// WithID adds the id to the users owners read params
+func (o *UsersOwnersReadParams) WithID(id int64) *UsersOwnersReadParams {
+	o.SetID(id)
+	return o
+}
+
+// SetID adds the id to the users owners read params
+func (o *UsersOwnersReadParams) SetID(id int64) {
+	o.ID = id
+}
+
+// WriteToRequest writes these params to a swagger request
+func (o *UsersOwnersReadParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.Registry) error {
+
+	if err := r.SetTimeout(o.timeout); err != nil {
+		return err
+	}
+	var res []error
+
+	// path param id
+	if err := r.SetPathParam("id", swag.FormatInt64(o.ID)); err != nil {
+		return err
+	}
+
+	if len(res) > 0 {
+		return errors.CompositeValidationError(res...)
+	}
+	return nil
+}

--- a/netbox/client/users/users_owners_read_responses.go
+++ b/netbox/client/users/users_owners_read_responses.go
@@ -1,0 +1,199 @@
+// Copyright 2020 The go-netbox Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package users
+
+// This file was manually added to extend the client with NetBox's Owner/OwnerGroup
+// endpoints (netbox-community/netbox users app), which are not yet covered by the
+// upstream swagger-generated client.
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+
+	"github.com/go-openapi/runtime"
+	"github.com/go-openapi/strfmt"
+
+	"github.com/fbreckle/go-netbox/netbox/models"
+)
+
+// UsersOwnersReadReader is a Reader for the UsersOwnersRead structure.
+type UsersOwnersReadReader struct {
+	formats strfmt.Registry
+}
+
+// ReadResponse reads a server response into the received o.
+func (o *UsersOwnersReadReader) ReadResponse(response runtime.ClientResponse, consumer runtime.Consumer) (interface{}, error) {
+	switch response.Code() {
+	case 200:
+		result := NewUsersOwnersReadOK()
+		if err := result.readResponse(response, consumer, o.formats); err != nil {
+			return nil, err
+		}
+		return result, nil
+	default:
+		result := NewUsersOwnersReadDefault(response.Code())
+		if err := result.readResponse(response, consumer, o.formats); err != nil {
+			return nil, err
+		}
+		if response.Code()/100 == 2 {
+			return result, nil
+		}
+		return nil, result
+	}
+}
+
+// NewUsersOwnersReadOK creates a UsersOwnersReadOK with default headers values
+func NewUsersOwnersReadOK() *UsersOwnersReadOK {
+	return &UsersOwnersReadOK{}
+}
+
+/*
+UsersOwnersReadOK describes a response with status code 200, with default header values.
+
+UsersOwnersReadOK users owners read o k
+*/
+type UsersOwnersReadOK struct {
+	Payload *models.Owner
+}
+
+// IsSuccess returns true when this users owners read o k response has a 2xx status code
+func (o *UsersOwnersReadOK) IsSuccess() bool {
+	return true
+}
+
+// IsRedirect returns true when this users owners read o k response has a 3xx status code
+func (o *UsersOwnersReadOK) IsRedirect() bool {
+	return false
+}
+
+// IsClientError returns true when this users owners read o k response has a 4xx status code
+func (o *UsersOwnersReadOK) IsClientError() bool {
+	return false
+}
+
+// IsServerError returns true when this users owners read o k response has a 5xx status code
+func (o *UsersOwnersReadOK) IsServerError() bool {
+	return false
+}
+
+// IsCode returns true when this users owners read o k response a status code equal to that given
+func (o *UsersOwnersReadOK) IsCode(code int) bool {
+	return code == 200
+}
+
+// Code gets the status code for the users owners read o k response
+func (o *UsersOwnersReadOK) Code() int {
+	return 200
+}
+
+func (o *UsersOwnersReadOK) Error() string {
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /users/owners/{id}/][%d] usersOwnersReadOK %s", 200, payload)
+}
+
+func (o *UsersOwnersReadOK) String() string {
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /users/owners/{id}/][%d] usersOwnersReadOK %s", 200, payload)
+}
+
+func (o *UsersOwnersReadOK) GetPayload() *models.Owner {
+	return o.Payload
+}
+
+func (o *UsersOwnersReadOK) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
+
+	o.Payload = new(models.Owner)
+
+	// response payload
+	if err := consumer.Consume(response.Body(), o.Payload); err != nil && err != io.EOF {
+		return err
+	}
+
+	return nil
+}
+
+// NewUsersOwnersReadDefault creates a UsersOwnersReadDefault with default headers values
+func NewUsersOwnersReadDefault(code int) *UsersOwnersReadDefault {
+	return &UsersOwnersReadDefault{
+		_statusCode: code,
+	}
+}
+
+/*
+UsersOwnersReadDefault describes a response with status code -1, with default header values.
+
+UsersOwnersReadDefault users owners read default
+*/
+type UsersOwnersReadDefault struct {
+	_statusCode int
+
+	Payload interface{}
+}
+
+// IsSuccess returns true when this users owners read default response has a 2xx status code
+func (o *UsersOwnersReadDefault) IsSuccess() bool {
+	return o._statusCode/100 == 2
+}
+
+// IsRedirect returns true when this users owners read default response has a 3xx status code
+func (o *UsersOwnersReadDefault) IsRedirect() bool {
+	return o._statusCode/100 == 3
+}
+
+// IsClientError returns true when this users owners read default response has a 4xx status code
+func (o *UsersOwnersReadDefault) IsClientError() bool {
+	return o._statusCode/100 == 4
+}
+
+// IsServerError returns true when this users owners read default response has a 5xx status code
+func (o *UsersOwnersReadDefault) IsServerError() bool {
+	return o._statusCode/100 == 5
+}
+
+// IsCode returns true when this users owners read default response a status code equal to that given
+func (o *UsersOwnersReadDefault) IsCode(code int) bool {
+	return o._statusCode == code
+}
+
+// Code gets the status code for the users owners read default response
+func (o *UsersOwnersReadDefault) Code() int {
+	return o._statusCode
+}
+
+func (o *UsersOwnersReadDefault) Error() string {
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /users/owners/{id}/][%d] users_owners_read default %s", o._statusCode, payload)
+}
+
+func (o *UsersOwnersReadDefault) String() string {
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /users/owners/{id}/][%d] users_owners_read default %s", o._statusCode, payload)
+}
+
+func (o *UsersOwnersReadDefault) GetPayload() interface{} {
+	return o.Payload
+}
+
+func (o *UsersOwnersReadDefault) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
+
+	// response payload
+	if err := consumer.Consume(response.Body(), &o.Payload); err != nil && err != io.EOF {
+		return err
+	}
+
+	return nil
+}

--- a/netbox/client/users/users_owners_update_parameters.go
+++ b/netbox/client/users/users_owners_update_parameters.go
@@ -1,0 +1,187 @@
+// Copyright 2020 The go-netbox Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package users
+
+// This file was manually added to extend the client with NetBox's Owner/OwnerGroup
+// endpoints (netbox-community/netbox users app), which are not yet covered by the
+// upstream swagger-generated client.
+
+import (
+	"context"
+	"net/http"
+	"time"
+
+	"github.com/go-openapi/errors"
+	"github.com/go-openapi/runtime"
+	cr "github.com/go-openapi/runtime/client"
+	"github.com/go-openapi/strfmt"
+	"github.com/go-openapi/swag"
+
+	"github.com/fbreckle/go-netbox/netbox/models"
+)
+
+// NewUsersOwnersUpdateParams creates a new UsersOwnersUpdateParams object,
+// with the default timeout for this client.
+//
+// Default values are not hydrated, since defaults are normally applied by the API server side.
+//
+// To enforce default values in parameter, use SetDefaults or WithDefaults.
+func NewUsersOwnersUpdateParams() *UsersOwnersUpdateParams {
+	return &UsersOwnersUpdateParams{
+		timeout: cr.DefaultTimeout,
+	}
+}
+
+// NewUsersOwnersUpdateParamsWithTimeout creates a new UsersOwnersUpdateParams object
+// with the ability to set a timeout on a request.
+func NewUsersOwnersUpdateParamsWithTimeout(timeout time.Duration) *UsersOwnersUpdateParams {
+	return &UsersOwnersUpdateParams{
+		timeout: timeout,
+	}
+}
+
+// NewUsersOwnersUpdateParamsWithContext creates a new UsersOwnersUpdateParams object
+// with the ability to set a context for a request.
+func NewUsersOwnersUpdateParamsWithContext(ctx context.Context) *UsersOwnersUpdateParams {
+	return &UsersOwnersUpdateParams{
+		Context: ctx,
+	}
+}
+
+// NewUsersOwnersUpdateParamsWithHTTPClient creates a new UsersOwnersUpdateParams object
+// with the ability to set a custom HTTPClient for a request.
+func NewUsersOwnersUpdateParamsWithHTTPClient(client *http.Client) *UsersOwnersUpdateParams {
+	return &UsersOwnersUpdateParams{
+		HTTPClient: client,
+	}
+}
+
+/*
+UsersOwnersUpdateParams contains all the parameters to send to the API endpoint
+
+	for the users owners update operation.
+
+	Typically these are written to a http.Request.
+*/
+type UsersOwnersUpdateParams struct {
+
+	// Data.
+	Data *models.WritableOwner
+
+	/* ID.
+
+	   A unique integer value identifying this owner.
+	*/
+	ID int64
+
+	timeout    time.Duration
+	Context    context.Context
+	HTTPClient *http.Client
+}
+
+// WithDefaults hydrates default values in the users owners update params (not the query body).
+//
+// All values with no default are reset to their zero value.
+func (o *UsersOwnersUpdateParams) WithDefaults() *UsersOwnersUpdateParams {
+	o.SetDefaults()
+	return o
+}
+
+// SetDefaults hydrates default values in the users owners update params (not the query body).
+//
+// All values with no default are reset to their zero value.
+func (o *UsersOwnersUpdateParams) SetDefaults() {
+	// no default values defined for this parameter
+}
+
+// WithTimeout adds the timeout to the users owners update params
+func (o *UsersOwnersUpdateParams) WithTimeout(timeout time.Duration) *UsersOwnersUpdateParams {
+	o.SetTimeout(timeout)
+	return o
+}
+
+// SetTimeout adds the timeout to the users owners update params
+func (o *UsersOwnersUpdateParams) SetTimeout(timeout time.Duration) {
+	o.timeout = timeout
+}
+
+// WithContext adds the context to the users owners update params
+func (o *UsersOwnersUpdateParams) WithContext(ctx context.Context) *UsersOwnersUpdateParams {
+	o.SetContext(ctx)
+	return o
+}
+
+// SetContext adds the context to the users owners update params
+func (o *UsersOwnersUpdateParams) SetContext(ctx context.Context) {
+	o.Context = ctx
+}
+
+// WithHTTPClient adds the HTTPClient to the users owners update params
+func (o *UsersOwnersUpdateParams) WithHTTPClient(client *http.Client) *UsersOwnersUpdateParams {
+	o.SetHTTPClient(client)
+	return o
+}
+
+// SetHTTPClient adds the HTTPClient to the users owners update params
+func (o *UsersOwnersUpdateParams) SetHTTPClient(client *http.Client) {
+	o.HTTPClient = client
+}
+
+// WithData adds the data to the users owners update params
+func (o *UsersOwnersUpdateParams) WithData(data *models.WritableOwner) *UsersOwnersUpdateParams {
+	o.SetData(data)
+	return o
+}
+
+// SetData adds the data to the users owners update params
+func (o *UsersOwnersUpdateParams) SetData(data *models.WritableOwner) {
+	o.Data = data
+}
+
+// WithID adds the id to the users owners update params
+func (o *UsersOwnersUpdateParams) WithID(id int64) *UsersOwnersUpdateParams {
+	o.SetID(id)
+	return o
+}
+
+// SetID adds the id to the users owners update params
+func (o *UsersOwnersUpdateParams) SetID(id int64) {
+	o.ID = id
+}
+
+// WriteToRequest writes these params to a swagger request
+func (o *UsersOwnersUpdateParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.Registry) error {
+
+	if err := r.SetTimeout(o.timeout); err != nil {
+		return err
+	}
+	var res []error
+	if o.Data != nil {
+		if err := r.SetBodyParam(o.Data); err != nil {
+			return err
+		}
+	}
+
+	// path param id
+	if err := r.SetPathParam("id", swag.FormatInt64(o.ID)); err != nil {
+		return err
+	}
+
+	if len(res) > 0 {
+		return errors.CompositeValidationError(res...)
+	}
+	return nil
+}

--- a/netbox/client/users/users_owners_update_responses.go
+++ b/netbox/client/users/users_owners_update_responses.go
@@ -67,7 +67,7 @@ UsersOwnersUpdateOK describes a response with status code 200, with default head
 UsersOwnersUpdateOK users owners update o k
 */
 type UsersOwnersUpdateOK struct {
-	Payload *models.WritableOwner
+	Payload *models.Owner
 }
 
 // IsSuccess returns true when this users owners update o k response has a 2xx status code
@@ -110,13 +110,13 @@ func (o *UsersOwnersUpdateOK) String() string {
 	return fmt.Sprintf("[PUT /users/owners/{id}/][%d] usersOwnersUpdateOK %s", 200, payload)
 }
 
-func (o *UsersOwnersUpdateOK) GetPayload() *models.WritableOwner {
+func (o *UsersOwnersUpdateOK) GetPayload() *models.Owner {
 	return o.Payload
 }
 
 func (o *UsersOwnersUpdateOK) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
 
-	o.Payload = new(models.WritableOwner)
+	o.Payload = new(models.Owner)
 
 	// response payload
 	if err := consumer.Consume(response.Body(), o.Payload); err != nil && err != io.EOF {

--- a/netbox/client/users/users_owners_update_responses.go
+++ b/netbox/client/users/users_owners_update_responses.go
@@ -1,0 +1,199 @@
+// Copyright 2020 The go-netbox Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package users
+
+// This file was manually added to extend the client with NetBox's Owner/OwnerGroup
+// endpoints (netbox-community/netbox users app), which are not yet covered by the
+// upstream swagger-generated client.
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+
+	"github.com/go-openapi/runtime"
+	"github.com/go-openapi/strfmt"
+
+	"github.com/fbreckle/go-netbox/netbox/models"
+)
+
+// UsersOwnersUpdateReader is a Reader for the UsersOwnersUpdate structure.
+type UsersOwnersUpdateReader struct {
+	formats strfmt.Registry
+}
+
+// ReadResponse reads a server response into the received o.
+func (o *UsersOwnersUpdateReader) ReadResponse(response runtime.ClientResponse, consumer runtime.Consumer) (interface{}, error) {
+	switch response.Code() {
+	case 200:
+		result := NewUsersOwnersUpdateOK()
+		if err := result.readResponse(response, consumer, o.formats); err != nil {
+			return nil, err
+		}
+		return result, nil
+	default:
+		result := NewUsersOwnersUpdateDefault(response.Code())
+		if err := result.readResponse(response, consumer, o.formats); err != nil {
+			return nil, err
+		}
+		if response.Code()/100 == 2 {
+			return result, nil
+		}
+		return nil, result
+	}
+}
+
+// NewUsersOwnersUpdateOK creates a UsersOwnersUpdateOK with default headers values
+func NewUsersOwnersUpdateOK() *UsersOwnersUpdateOK {
+	return &UsersOwnersUpdateOK{}
+}
+
+/*
+UsersOwnersUpdateOK describes a response with status code 200, with default header values.
+
+UsersOwnersUpdateOK users owners update o k
+*/
+type UsersOwnersUpdateOK struct {
+	Payload *models.WritableOwner
+}
+
+// IsSuccess returns true when this users owners update o k response has a 2xx status code
+func (o *UsersOwnersUpdateOK) IsSuccess() bool {
+	return true
+}
+
+// IsRedirect returns true when this users owners update o k response has a 3xx status code
+func (o *UsersOwnersUpdateOK) IsRedirect() bool {
+	return false
+}
+
+// IsClientError returns true when this users owners update o k response has a 4xx status code
+func (o *UsersOwnersUpdateOK) IsClientError() bool {
+	return false
+}
+
+// IsServerError returns true when this users owners update o k response has a 5xx status code
+func (o *UsersOwnersUpdateOK) IsServerError() bool {
+	return false
+}
+
+// IsCode returns true when this users owners update o k response a status code equal to that given
+func (o *UsersOwnersUpdateOK) IsCode(code int) bool {
+	return code == 200
+}
+
+// Code gets the status code for the users owners update o k response
+func (o *UsersOwnersUpdateOK) Code() int {
+	return 200
+}
+
+func (o *UsersOwnersUpdateOK) Error() string {
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[PUT /users/owners/{id}/][%d] usersOwnersUpdateOK %s", 200, payload)
+}
+
+func (o *UsersOwnersUpdateOK) String() string {
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[PUT /users/owners/{id}/][%d] usersOwnersUpdateOK %s", 200, payload)
+}
+
+func (o *UsersOwnersUpdateOK) GetPayload() *models.WritableOwner {
+	return o.Payload
+}
+
+func (o *UsersOwnersUpdateOK) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
+
+	o.Payload = new(models.WritableOwner)
+
+	// response payload
+	if err := consumer.Consume(response.Body(), o.Payload); err != nil && err != io.EOF {
+		return err
+	}
+
+	return nil
+}
+
+// NewUsersOwnersUpdateDefault creates a UsersOwnersUpdateDefault with default headers values
+func NewUsersOwnersUpdateDefault(code int) *UsersOwnersUpdateDefault {
+	return &UsersOwnersUpdateDefault{
+		_statusCode: code,
+	}
+}
+
+/*
+UsersOwnersUpdateDefault describes a response with status code -1, with default header values.
+
+UsersOwnersUpdateDefault users owners update default
+*/
+type UsersOwnersUpdateDefault struct {
+	_statusCode int
+
+	Payload interface{}
+}
+
+// IsSuccess returns true when this users owners update default response has a 2xx status code
+func (o *UsersOwnersUpdateDefault) IsSuccess() bool {
+	return o._statusCode/100 == 2
+}
+
+// IsRedirect returns true when this users owners update default response has a 3xx status code
+func (o *UsersOwnersUpdateDefault) IsRedirect() bool {
+	return o._statusCode/100 == 3
+}
+
+// IsClientError returns true when this users owners update default response has a 4xx status code
+func (o *UsersOwnersUpdateDefault) IsClientError() bool {
+	return o._statusCode/100 == 4
+}
+
+// IsServerError returns true when this users owners update default response has a 5xx status code
+func (o *UsersOwnersUpdateDefault) IsServerError() bool {
+	return o._statusCode/100 == 5
+}
+
+// IsCode returns true when this users owners update default response a status code equal to that given
+func (o *UsersOwnersUpdateDefault) IsCode(code int) bool {
+	return o._statusCode == code
+}
+
+// Code gets the status code for the users owners update default response
+func (o *UsersOwnersUpdateDefault) Code() int {
+	return o._statusCode
+}
+
+func (o *UsersOwnersUpdateDefault) Error() string {
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[PUT /users/owners/{id}/][%d] users_owners_update default %s", o._statusCode, payload)
+}
+
+func (o *UsersOwnersUpdateDefault) String() string {
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[PUT /users/owners/{id}/][%d] users_owners_update default %s", o._statusCode, payload)
+}
+
+func (o *UsersOwnersUpdateDefault) GetPayload() interface{} {
+	return o.Payload
+}
+
+func (o *UsersOwnersUpdateDefault) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
+
+	// response payload
+	if err := consumer.Consume(response.Body(), &o.Payload); err != nil && err != io.EOF {
+		return err
+	}
+
+	return nil
+}

--- a/netbox/models/nested_owner_group.go
+++ b/netbox/models/nested_owner_group.go
@@ -1,0 +1,188 @@
+// Copyright 2020 The go-netbox Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package models
+
+// This file was manually added to extend the client with NetBox's Owner/OwnerGroup
+// endpoints (netbox-community/netbox users app), which are not yet covered by the
+// upstream swagger-generated client.
+
+import (
+	"context"
+
+	"github.com/go-openapi/errors"
+	"github.com/go-openapi/strfmt"
+	"github.com/go-openapi/swag"
+	"github.com/go-openapi/validate"
+)
+
+// NestedOwnerGroup nested owner group
+//
+// swagger:model NestedOwnerGroup
+type NestedOwnerGroup struct {
+
+	// Description
+	// Max Length: 200
+	Description string `json:"description,omitempty"`
+
+	// Display
+	// Read Only: true
+	Display string `json:"display,omitempty"`
+
+	// ID
+	// Read Only: true
+	ID int64 `json:"id,omitempty"`
+
+	// Name
+	// Required: true
+	// Max Length: 100
+	// Min Length: 1
+	Name *string `json:"name"`
+
+	// Url
+	// Read Only: true
+	// Format: uri
+	URL strfmt.URI `json:"url,omitempty"`
+}
+
+// Validate validates this nested owner group
+func (m *NestedOwnerGroup) Validate(formats strfmt.Registry) error {
+	var res []error
+
+	if err := m.validateDescription(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.validateName(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.validateURL(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if len(res) > 0 {
+		return errors.CompositeValidationError(res...)
+	}
+	return nil
+}
+
+func (m *NestedOwnerGroup) validateDescription(formats strfmt.Registry) error {
+	if swag.IsZero(m.Description) { // not required
+		return nil
+	}
+
+	if err := validate.MaxLength("description", "body", m.Description, 200); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (m *NestedOwnerGroup) validateName(formats strfmt.Registry) error {
+
+	if err := validate.Required("name", "body", m.Name); err != nil {
+		return err
+	}
+
+	if err := validate.MinLength("name", "body", *m.Name, 1); err != nil {
+		return err
+	}
+
+	if err := validate.MaxLength("name", "body", *m.Name, 100); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (m *NestedOwnerGroup) validateURL(formats strfmt.Registry) error {
+	if swag.IsZero(m.URL) { // not required
+		return nil
+	}
+
+	if err := validate.FormatOf("url", "body", "uri", m.URL.String(), formats); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// ContextValidate validate this nested owner group based on the context it is used
+func (m *NestedOwnerGroup) ContextValidate(ctx context.Context, formats strfmt.Registry) error {
+	var res []error
+
+	if err := m.contextValidateDisplay(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.contextValidateID(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.contextValidateURL(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
+	if len(res) > 0 {
+		return errors.CompositeValidationError(res...)
+	}
+	return nil
+}
+
+func (m *NestedOwnerGroup) contextValidateDisplay(ctx context.Context, formats strfmt.Registry) error {
+
+	if err := validate.ReadOnly(ctx, "display", "body", string(m.Display)); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (m *NestedOwnerGroup) contextValidateID(ctx context.Context, formats strfmt.Registry) error {
+
+	if err := validate.ReadOnly(ctx, "id", "body", int64(m.ID)); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (m *NestedOwnerGroup) contextValidateURL(ctx context.Context, formats strfmt.Registry) error {
+
+	if err := validate.ReadOnly(ctx, "url", "body", strfmt.URI(m.URL)); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// MarshalBinary interface implementation
+func (m *NestedOwnerGroup) MarshalBinary() ([]byte, error) {
+	if m == nil {
+		return nil, nil
+	}
+	return swag.WriteJSON(m)
+}
+
+// UnmarshalBinary interface implementation
+func (m *NestedOwnerGroup) UnmarshalBinary(b []byte) error {
+	var res NestedOwnerGroup
+	if err := swag.ReadJSON(b, &res); err != nil {
+		return err
+	}
+	*m = res
+	return nil
+}

--- a/netbox/models/owner.go
+++ b/netbox/models/owner.go
@@ -1,0 +1,398 @@
+// Copyright 2020 The go-netbox Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package models
+
+// This file was manually added to extend the client with NetBox's Owner/OwnerGroup
+// endpoints (netbox-community/netbox users app), which are not yet covered by the
+// upstream swagger-generated client.
+
+import (
+	"context"
+	"strconv"
+
+	"github.com/go-openapi/errors"
+	"github.com/go-openapi/strfmt"
+	"github.com/go-openapi/swag"
+	"github.com/go-openapi/validate"
+)
+
+// Owner owner
+//
+// swagger:model Owner
+type Owner struct {
+
+	// Description
+	// Max Length: 200
+	Description string `json:"description,omitempty"`
+
+	// Display
+	// Read Only: true
+	Display string `json:"display,omitempty"`
+
+	// Display url
+	// Read Only: true
+	// Format: uri
+	DisplayURL strfmt.URI `json:"display_url,omitempty"`
+
+	// group
+	Group *NestedOwnerGroup `json:"group,omitempty"`
+
+	// ID
+	// Read Only: true
+	ID int64 `json:"id,omitempty"`
+
+	// Name
+	// Required: true
+	// Max Length: 100
+	// Min Length: 1
+	Name *string `json:"name"`
+
+	// Url
+	// Read Only: true
+	// Format: uri
+	URL strfmt.URI `json:"url,omitempty"`
+
+	// user groups
+	UserGroups []*NestedGroup `json:"user_groups"`
+
+	// users
+	Users []*NestedUser `json:"users"`
+}
+
+// Validate validates this owner
+func (m *Owner) Validate(formats strfmt.Registry) error {
+	var res []error
+
+	if err := m.validateDescription(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.validateDisplayURL(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.validateGroup(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.validateName(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.validateURL(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.validateUserGroups(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.validateUsers(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if len(res) > 0 {
+		return errors.CompositeValidationError(res...)
+	}
+	return nil
+}
+
+func (m *Owner) validateDescription(formats strfmt.Registry) error {
+	if swag.IsZero(m.Description) { // not required
+		return nil
+	}
+
+	if err := validate.MaxLength("description", "body", m.Description, 200); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (m *Owner) validateDisplayURL(formats strfmt.Registry) error {
+	if swag.IsZero(m.DisplayURL) { // not required
+		return nil
+	}
+
+	if err := validate.FormatOf("display_url", "body", "uri", m.DisplayURL.String(), formats); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (m *Owner) validateGroup(formats strfmt.Registry) error {
+	if swag.IsZero(m.Group) { // not required
+		return nil
+	}
+
+	if m.Group != nil {
+		if err := m.Group.Validate(formats); err != nil {
+			if ve, ok := err.(*errors.Validation); ok {
+				return ve.ValidateName("group")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("group")
+			}
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (m *Owner) validateName(formats strfmt.Registry) error {
+
+	if err := validate.Required("name", "body", m.Name); err != nil {
+		return err
+	}
+
+	if err := validate.MinLength("name", "body", *m.Name, 1); err != nil {
+		return err
+	}
+
+	if err := validate.MaxLength("name", "body", *m.Name, 100); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (m *Owner) validateURL(formats strfmt.Registry) error {
+	if swag.IsZero(m.URL) { // not required
+		return nil
+	}
+
+	if err := validate.FormatOf("url", "body", "uri", m.URL.String(), formats); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (m *Owner) validateUserGroups(formats strfmt.Registry) error {
+	if swag.IsZero(m.UserGroups) { // not required
+		return nil
+	}
+
+	for i := 0; i < len(m.UserGroups); i++ {
+		if swag.IsZero(m.UserGroups[i]) { // not required
+			continue
+		}
+
+		if m.UserGroups[i] != nil {
+			if err := m.UserGroups[i].Validate(formats); err != nil {
+				if ve, ok := err.(*errors.Validation); ok {
+					return ve.ValidateName("user_groups" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("user_groups" + "." + strconv.Itoa(i))
+				}
+				return err
+			}
+		}
+
+	}
+
+	return nil
+}
+
+func (m *Owner) validateUsers(formats strfmt.Registry) error {
+	if swag.IsZero(m.Users) { // not required
+		return nil
+	}
+
+	for i := 0; i < len(m.Users); i++ {
+		if swag.IsZero(m.Users[i]) { // not required
+			continue
+		}
+
+		if m.Users[i] != nil {
+			if err := m.Users[i].Validate(formats); err != nil {
+				if ve, ok := err.(*errors.Validation); ok {
+					return ve.ValidateName("users" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("users" + "." + strconv.Itoa(i))
+				}
+				return err
+			}
+		}
+
+	}
+
+	return nil
+}
+
+// ContextValidate validate this owner based on the context it is used
+func (m *Owner) ContextValidate(ctx context.Context, formats strfmt.Registry) error {
+	var res []error
+
+	if err := m.contextValidateDisplay(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.contextValidateDisplayURL(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.contextValidateGroup(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.contextValidateID(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.contextValidateURL(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.contextValidateUserGroups(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.contextValidateUsers(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
+	if len(res) > 0 {
+		return errors.CompositeValidationError(res...)
+	}
+	return nil
+}
+
+func (m *Owner) contextValidateDisplay(ctx context.Context, formats strfmt.Registry) error {
+
+	if err := validate.ReadOnly(ctx, "display", "body", string(m.Display)); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (m *Owner) contextValidateDisplayURL(ctx context.Context, formats strfmt.Registry) error {
+
+	if err := validate.ReadOnly(ctx, "display_url", "body", strfmt.URI(m.DisplayURL)); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (m *Owner) contextValidateGroup(ctx context.Context, formats strfmt.Registry) error {
+
+	if m.Group != nil {
+
+		if swag.IsZero(m.Group) { // not required
+			return nil
+		}
+
+		if err := m.Group.ContextValidate(ctx, formats); err != nil {
+			if ve, ok := err.(*errors.Validation); ok {
+				return ve.ValidateName("group")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("group")
+			}
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (m *Owner) contextValidateID(ctx context.Context, formats strfmt.Registry) error {
+
+	if err := validate.ReadOnly(ctx, "id", "body", int64(m.ID)); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (m *Owner) contextValidateURL(ctx context.Context, formats strfmt.Registry) error {
+
+	if err := validate.ReadOnly(ctx, "url", "body", strfmt.URI(m.URL)); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (m *Owner) contextValidateUserGroups(ctx context.Context, formats strfmt.Registry) error {
+
+	for i := 0; i < len(m.UserGroups); i++ {
+
+		if m.UserGroups[i] != nil {
+
+			if swag.IsZero(m.UserGroups[i]) { // not required
+				return nil
+			}
+
+			if err := m.UserGroups[i].ContextValidate(ctx, formats); err != nil {
+				if ve, ok := err.(*errors.Validation); ok {
+					return ve.ValidateName("user_groups" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("user_groups" + "." + strconv.Itoa(i))
+				}
+				return err
+			}
+		}
+
+	}
+
+	return nil
+}
+
+func (m *Owner) contextValidateUsers(ctx context.Context, formats strfmt.Registry) error {
+
+	for i := 0; i < len(m.Users); i++ {
+
+		if m.Users[i] != nil {
+
+			if swag.IsZero(m.Users[i]) { // not required
+				return nil
+			}
+
+			if err := m.Users[i].ContextValidate(ctx, formats); err != nil {
+				if ve, ok := err.(*errors.Validation); ok {
+					return ve.ValidateName("users" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("users" + "." + strconv.Itoa(i))
+				}
+				return err
+			}
+		}
+
+	}
+
+	return nil
+}
+
+// MarshalBinary interface implementation
+func (m *Owner) MarshalBinary() ([]byte, error) {
+	if m == nil {
+		return nil, nil
+	}
+	return swag.WriteJSON(m)
+}
+
+// UnmarshalBinary interface implementation
+func (m *Owner) UnmarshalBinary(b []byte) error {
+	var res Owner
+	if err := swag.ReadJSON(b, &res); err != nil {
+		return err
+	}
+	*m = res
+	return nil
+}

--- a/netbox/models/owner_group.go
+++ b/netbox/models/owner_group.go
@@ -1,0 +1,239 @@
+// Copyright 2020 The go-netbox Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package models
+
+// This file was manually added to extend the client with NetBox's Owner/OwnerGroup
+// endpoints (netbox-community/netbox users app), which are not yet covered by the
+// upstream swagger-generated client.
+
+import (
+	"context"
+
+	"github.com/go-openapi/errors"
+	"github.com/go-openapi/strfmt"
+	"github.com/go-openapi/swag"
+	"github.com/go-openapi/validate"
+)
+
+// OwnerGroup owner group
+//
+// swagger:model OwnerGroup
+type OwnerGroup struct {
+
+	// Description
+	// Max Length: 200
+	Description string `json:"description,omitempty"`
+
+	// Display
+	// Read Only: true
+	Display string `json:"display,omitempty"`
+
+	// Display url
+	// Read Only: true
+	// Format: uri
+	DisplayURL strfmt.URI `json:"display_url,omitempty"`
+
+	// ID
+	// Read Only: true
+	ID int64 `json:"id,omitempty"`
+
+	// Member count
+	// Read Only: true
+	MemberCount int64 `json:"member_count,omitempty"`
+
+	// Name
+	// Required: true
+	// Max Length: 100
+	// Min Length: 1
+	Name *string `json:"name"`
+
+	// Url
+	// Read Only: true
+	// Format: uri
+	URL strfmt.URI `json:"url,omitempty"`
+}
+
+// Validate validates this owner group
+func (m *OwnerGroup) Validate(formats strfmt.Registry) error {
+	var res []error
+
+	if err := m.validateDescription(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.validateDisplayURL(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.validateName(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.validateURL(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if len(res) > 0 {
+		return errors.CompositeValidationError(res...)
+	}
+	return nil
+}
+
+func (m *OwnerGroup) validateDescription(formats strfmt.Registry) error {
+	if swag.IsZero(m.Description) { // not required
+		return nil
+	}
+
+	if err := validate.MaxLength("description", "body", m.Description, 200); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (m *OwnerGroup) validateDisplayURL(formats strfmt.Registry) error {
+	if swag.IsZero(m.DisplayURL) { // not required
+		return nil
+	}
+
+	if err := validate.FormatOf("display_url", "body", "uri", m.DisplayURL.String(), formats); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (m *OwnerGroup) validateName(formats strfmt.Registry) error {
+
+	if err := validate.Required("name", "body", m.Name); err != nil {
+		return err
+	}
+
+	if err := validate.MinLength("name", "body", *m.Name, 1); err != nil {
+		return err
+	}
+
+	if err := validate.MaxLength("name", "body", *m.Name, 100); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (m *OwnerGroup) validateURL(formats strfmt.Registry) error {
+	if swag.IsZero(m.URL) { // not required
+		return nil
+	}
+
+	if err := validate.FormatOf("url", "body", "uri", m.URL.String(), formats); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// ContextValidate validate this owner group based on the context it is used
+func (m *OwnerGroup) ContextValidate(ctx context.Context, formats strfmt.Registry) error {
+	var res []error
+
+	if err := m.contextValidateDisplay(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.contextValidateDisplayURL(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.contextValidateID(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.contextValidateMemberCount(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.contextValidateURL(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
+	if len(res) > 0 {
+		return errors.CompositeValidationError(res...)
+	}
+	return nil
+}
+
+func (m *OwnerGroup) contextValidateDisplay(ctx context.Context, formats strfmt.Registry) error {
+
+	if err := validate.ReadOnly(ctx, "display", "body", string(m.Display)); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (m *OwnerGroup) contextValidateDisplayURL(ctx context.Context, formats strfmt.Registry) error {
+
+	if err := validate.ReadOnly(ctx, "display_url", "body", strfmt.URI(m.DisplayURL)); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (m *OwnerGroup) contextValidateID(ctx context.Context, formats strfmt.Registry) error {
+
+	if err := validate.ReadOnly(ctx, "id", "body", int64(m.ID)); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (m *OwnerGroup) contextValidateMemberCount(ctx context.Context, formats strfmt.Registry) error {
+
+	if err := validate.ReadOnly(ctx, "member_count", "body", int64(m.MemberCount)); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (m *OwnerGroup) contextValidateURL(ctx context.Context, formats strfmt.Registry) error {
+
+	if err := validate.ReadOnly(ctx, "url", "body", strfmt.URI(m.URL)); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// MarshalBinary interface implementation
+func (m *OwnerGroup) MarshalBinary() ([]byte, error) {
+	if m == nil {
+		return nil, nil
+	}
+	return swag.WriteJSON(m)
+}
+
+// UnmarshalBinary interface implementation
+func (m *OwnerGroup) UnmarshalBinary(b []byte) error {
+	var res OwnerGroup
+	if err := swag.ReadJSON(b, &res); err != nil {
+		return err
+	}
+	*m = res
+	return nil
+}

--- a/netbox/models/writable_owner.go
+++ b/netbox/models/writable_owner.go
@@ -1,0 +1,231 @@
+// Copyright 2020 The go-netbox Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package models
+
+// This file was manually added to extend the client with NetBox's Owner/OwnerGroup
+// endpoints (netbox-community/netbox users app), which are not yet covered by the
+// upstream swagger-generated client.
+
+import (
+	"context"
+
+	"github.com/go-openapi/errors"
+	"github.com/go-openapi/strfmt"
+	"github.com/go-openapi/swag"
+	"github.com/go-openapi/validate"
+)
+
+// WritableOwner writable owner
+//
+// swagger:model WritableOwner
+type WritableOwner struct {
+
+	// Description
+	// Max Length: 200
+	Description string `json:"description,omitempty"`
+
+	// Display
+	// Read Only: true
+	Display string `json:"display,omitempty"`
+
+	// Display url
+	// Read Only: true
+	// Format: uri
+	DisplayURL strfmt.URI `json:"display_url,omitempty"`
+
+	// Group
+	Group *int64 `json:"group,omitempty"`
+
+	// ID
+	// Read Only: true
+	ID int64 `json:"id,omitempty"`
+
+	// Name
+	// Required: true
+	// Max Length: 100
+	// Min Length: 1
+	Name *string `json:"name"`
+
+	// Url
+	// Read Only: true
+	// Format: uri
+	URL strfmt.URI `json:"url,omitempty"`
+
+	// User groups
+	UserGroups []int64 `json:"user_groups"`
+
+	// Users
+	Users []int64 `json:"users"`
+}
+
+// Validate validates this writable owner
+func (m *WritableOwner) Validate(formats strfmt.Registry) error {
+	var res []error
+
+	if err := m.validateDescription(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.validateDisplayURL(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.validateName(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.validateURL(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if len(res) > 0 {
+		return errors.CompositeValidationError(res...)
+	}
+	return nil
+}
+
+func (m *WritableOwner) validateDescription(formats strfmt.Registry) error {
+	if swag.IsZero(m.Description) { // not required
+		return nil
+	}
+
+	if err := validate.MaxLength("description", "body", m.Description, 200); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (m *WritableOwner) validateDisplayURL(formats strfmt.Registry) error {
+	if swag.IsZero(m.DisplayURL) { // not required
+		return nil
+	}
+
+	if err := validate.FormatOf("display_url", "body", "uri", m.DisplayURL.String(), formats); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (m *WritableOwner) validateName(formats strfmt.Registry) error {
+
+	if err := validate.Required("name", "body", m.Name); err != nil {
+		return err
+	}
+
+	if err := validate.MinLength("name", "body", *m.Name, 1); err != nil {
+		return err
+	}
+
+	if err := validate.MaxLength("name", "body", *m.Name, 100); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (m *WritableOwner) validateURL(formats strfmt.Registry) error {
+	if swag.IsZero(m.URL) { // not required
+		return nil
+	}
+
+	if err := validate.FormatOf("url", "body", "uri", m.URL.String(), formats); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// ContextValidate validate this writable owner based on the context it is used
+func (m *WritableOwner) ContextValidate(ctx context.Context, formats strfmt.Registry) error {
+	var res []error
+
+	if err := m.contextValidateDisplay(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.contextValidateDisplayURL(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.contextValidateID(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.contextValidateURL(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
+	if len(res) > 0 {
+		return errors.CompositeValidationError(res...)
+	}
+	return nil
+}
+
+func (m *WritableOwner) contextValidateDisplay(ctx context.Context, formats strfmt.Registry) error {
+
+	if err := validate.ReadOnly(ctx, "display", "body", string(m.Display)); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (m *WritableOwner) contextValidateDisplayURL(ctx context.Context, formats strfmt.Registry) error {
+
+	if err := validate.ReadOnly(ctx, "display_url", "body", strfmt.URI(m.DisplayURL)); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (m *WritableOwner) contextValidateID(ctx context.Context, formats strfmt.Registry) error {
+
+	if err := validate.ReadOnly(ctx, "id", "body", int64(m.ID)); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (m *WritableOwner) contextValidateURL(ctx context.Context, formats strfmt.Registry) error {
+
+	if err := validate.ReadOnly(ctx, "url", "body", strfmt.URI(m.URL)); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// MarshalBinary interface implementation
+func (m *WritableOwner) MarshalBinary() ([]byte, error) {
+	if m == nil {
+		return nil, nil
+	}
+	return swag.WriteJSON(m)
+}
+
+// UnmarshalBinary interface implementation
+func (m *WritableOwner) UnmarshalBinary(b []byte) error {
+	var res WritableOwner
+	if err := swag.ReadJSON(b, &res); err != nil {
+		return err
+	}
+	*m = res
+	return nil
+}

--- a/netbox/models/writable_owner.go
+++ b/netbox/models/writable_owner.go
@@ -47,7 +47,11 @@ type WritableOwner struct {
 	DisplayURL strfmt.URI `json:"display_url,omitempty"`
 
 	// Group
-	Group *int64 `json:"group,omitempty"`
+	// NetBox's Owner API declares this field without required=False, so the
+	// key must always be present in the request body (as null or an id) --
+	// omitempty would drop it entirely and the API rejects the request with
+	// {"group":["This field is required."]}.
+	Group *int64 `json:"group"`
 
 	// ID
 	// Read Only: true


### PR DESCRIPTION
## Summary
NetBox added an `Owner`/`OwnerGroup` model to the `users` app in NetBox 4.5.0 ([netbox-community/netbox#20304](https://github.com/netbox-community/netbox/issues/20304)) for indicating administrative responsibility for objects (distinct from tenancy). This client doesn't have bindings for it yet, so this adds:

- Models: `Owner`, `OwnerGroup`, `NestedOwnerGroup`, `WritableOwner`
- Client operations for `/users/owners/` and `/users/owner-groups/` (create/read/update/partial_update/delete/list), following the same conventions as the existing generated code (see `users_groups_*.go`)

These files are hand-written rather than generated by the swagger tool, since I don't have the updated swagger/OpenAPI spec this repo generates from. Happy to adjust to match however you regenerate this client if that differs from what's here.

Verified against a live dockerized NetBox v4.6.4 instance while building [e-breuninger/terraform-provider-netbox#932](https://github.com/e-breuninger/terraform-provider-netbox/pull/932) (draft), which depends on this branch via a `replace` directive in the meantime. Two bugs were caught and fixed that way:
- `group` must always be present in the request body (even as `null`) since NetBox's `OwnerSerializer` doesn't mark it `required=False`.
- The create/update/partial_update responses always return the nested `Owner` representation for `group`/`user_groups`/`users`, never a flat-int shape.

Opening as a draft since I'm not sure this matches your preferred process for adding new endpoints (e.g. regenerating from an updated spec instead). Let me know if you'd like this done differently.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `gofmt -l` (clean)
- [x] Exercised via terraform-provider-netbox acceptance tests against live NetBox v4.6.4 (create/read/update/delete for both `netbox_owner` and `netbox_owner_group`)