### PR TITLE
fix: decode NestedPowerPort.cable as a NestedCable object

### DIFF
--- a/netbox/models/nested_power_port.go
+++ b/netbox/models/nested_power_port.go
@@ -38,8 +38,8 @@ type NestedPowerPort struct {
 	// Read Only: true
 	Occupied *bool `json:"_occupied,omitempty"`
 
-	// Cable
-	Cable *int64 `json:"cable,omitempty"`
+	// cable
+	Cable *NestedCable `json:"cable,omitempty"`
 
 	// device
 	Device *NestedDevice `json:"device,omitempty"`
@@ -68,6 +68,10 @@ type NestedPowerPort struct {
 func (m *NestedPowerPort) Validate(formats strfmt.Registry) error {
 	var res []error
 
+	if err := m.validateCable(formats); err != nil {
+		res = append(res, err)
+	}
+
 	if err := m.validateDevice(formats); err != nil {
 		res = append(res, err)
 	}
@@ -83,6 +87,25 @@ func (m *NestedPowerPort) Validate(formats strfmt.Registry) error {
 	if len(res) > 0 {
 		return errors.CompositeValidationError(res...)
 	}
+	return nil
+}
+
+func (m *NestedPowerPort) validateCable(formats strfmt.Registry) error {
+	if swag.IsZero(m.Cable) { // not required
+		return nil
+	}
+
+	if m.Cable != nil {
+		if err := m.Cable.Validate(formats); err != nil {
+			if ve, ok := err.(*errors.Validation); ok {
+				return ve.ValidateName("cable")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("cable")
+			}
+			return err
+		}
+	}
+
 	return nil
 }
 
@@ -142,6 +165,10 @@ func (m *NestedPowerPort) ContextValidate(ctx context.Context, formats strfmt.Re
 		res = append(res, err)
 	}
 
+	if err := m.contextValidateCable(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
 	if err := m.contextValidateDevice(ctx, formats); err != nil {
 		res = append(res, err)
 	}
@@ -168,6 +195,27 @@ func (m *NestedPowerPort) contextValidateOccupied(ctx context.Context, formats s
 
 	if err := validate.ReadOnly(ctx, "_occupied", "body", m.Occupied); err != nil {
 		return err
+	}
+
+	return nil
+}
+
+func (m *NestedPowerPort) contextValidateCable(ctx context.Context, formats strfmt.Registry) error {
+
+	if m.Cable != nil {
+
+		if swag.IsZero(m.Cable) { // not required
+			return nil
+		}
+
+		if err := m.Cable.ContextValidate(ctx, formats); err != nil {
+			if ve, ok := err.(*errors.Validation); ok {
+				return ve.ValidateName("cable")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("cable")
+			}
+			return err
+		}
 	}
 
 	return nil

--- a/swagger.json
+++ b/swagger.json
@@ -80497,9 +80497,7 @@
           "minLength": 1
         },
         "cable": {
-          "title": "Cable",
-          "type": "integer",
-          "x-nullable": true
+          "$ref": "#/definitions/NestedCable"
         },
         "_occupied": {
           "title": "occupied",

--- a/swagger.processed.json
+++ b/swagger.processed.json
@@ -80105,9 +80105,7 @@
           "minLength": 1
         },
         "cable": {
-          "title": "Cable",
-          "type": "integer",
-          "x-nullable": true
+          "$ref": "#/definitions/NestedCable"
         },
         "_occupied": {
           "title": "occupied",


### PR DESCRIPTION
## Problem

NetBox 4.x returns the `cable` field of a **nested** power port as an object (`id`/`url`/`display`/`label`), but the swagger spec types `NestedPowerPort.cable` as a bare `integer`. Any read that nests a cabled power port — e.g. a `PowerOutlet` whose `power_port` is cabled — fails to deserialize:

```
json: cannot unmarshal object into Go struct field NestedPowerPort.power_port.cable of type int64
```

This breaks reads of power outlets in the terraform-provider-netbox (`netbox_device_power_outlet`) the moment the parent power port has a cable.

## Fix

Change the `cable` property of `NestedPowerPort` from `type: integer` to `$ref: NestedCable` — the same shape the full `PowerPort` model already uses — in both `swagger.json` and `swagger.processed.json`, and regenerate. The generated field becomes:

```go
Cable *NestedCable `json:"cable,omitempty"`
```

Regeneration touches only `netbox/models/nested_power_port.go`.

## Verification

An unmarshal of a NetBox 4.x `PowerOutlet` payload whose nested `power_port.cable` is an object fails before this change with the error above and succeeds after it.

## Scope

The sibling `NestedInterface.cable` and `CableTermination.cable` share the same `integer` pattern and would benefit from the same migration, but are intentionally left untouched here to keep the change scoped to the reproduced bug.