### PR TITLE
fix: make oob_ip writable on WritableDeviceWithConfigContext

### DIFF
--- a/netbox/models/writable_device_with_config_context.go
+++ b/netbox/models/writable_device_with_config_context.go
@@ -103,8 +103,7 @@ type WritableDeviceWithConfigContext struct {
 	Name *string `json:"name,omitempty"`
 
 	// OOB ip
-	// Read Only: true
-	OobIP string `json:"oob_ip,omitempty"`
+	OobIP *int64 `json:"oob_ip,omitempty"`
 
 	// parent device
 	ParentDevice *NestedDevice `json:"parent_device,omitempty"`
@@ -628,10 +627,6 @@ func (m *WritableDeviceWithConfigContext) ContextValidate(ctx context.Context, f
 		res = append(res, err)
 	}
 
-	if err := m.contextValidateOobIP(ctx, formats); err != nil {
-		res = append(res, err)
-	}
-
 	if err := m.contextValidateParentDevice(ctx, formats); err != nil {
 		res = append(res, err)
 	}
@@ -684,15 +679,6 @@ func (m *WritableDeviceWithConfigContext) contextValidateID(ctx context.Context,
 func (m *WritableDeviceWithConfigContext) contextValidateLastUpdated(ctx context.Context, formats strfmt.Registry) error {
 
 	if err := validate.ReadOnly(ctx, "last_updated", "body", m.LastUpdated); err != nil {
-		return err
-	}
-
-	return nil
-}
-
-func (m *WritableDeviceWithConfigContext) contextValidateOobIP(ctx context.Context, formats strfmt.Registry) error {
-
-	if err := validate.ReadOnly(ctx, "oob_ip", "body", string(m.OobIP)); err != nil {
 		return err
 	}
 

--- a/swagger.processed.json
+++ b/swagger.processed.json
@@ -73715,8 +73715,8 @@
         },
         "oob_ip": {
           "title": "OOB ip",
-          "type": "string",
-          "readOnly": true
+          "type": "integer",
+          "x-nullable": true
         },
         "cluster": {
           "title": "Cluster",


### PR DESCRIPTION
## Problem

NetBox lets you set a device's out-of-band management IP (`oob_ip`) via the API, but the write model (`WritableDeviceWithConfigContext`) typed `oob_ip` as a **read-only `string`**, so it could never be set through the client — unlike `primary_ip4`/`primary_ip6`, which are writable integers in the same definition.

This blocks the terraform-provider-netbox from offering an OOB-IP resource.

## Fix

In `swagger.processed.json`, retype the writable `oob_ip` from `{type: string, readOnly: true}` to `{type: integer, x-nullable: true}` — identical to `primary_ip4`/`primary_ip6` — and regenerate. The generated field becomes:

```go
OobIP *int64 `json:"oob_ip,omitempty"`
```

and the read-only validation is dropped. Regeneration touches only `netbox/models/writable_device_with_config_context.go`.

The two read models (`Device`, `DeviceWithConfigContext`) keep `oob_ip` as a `NestedIPAddress` ref and are untouched.

> Note: `oob_ip` only exists in `swagger.processed.json` (not `swagger.json`), so only the processed spec is edited — consistent with how it was originally added.

## Verification

A terraform-provider-netbox resource that sets `oob_ip` via `DcimDevicesPartialUpdate` and reads it back round-trips successfully against NetBox 4.4.10 with this change (and does not compile without it, since the field must be `*int64`).