### PR TITLE
fix: make DeviceRole.vm_role nullable so false can be sent

### DIFF
--- a/netbox/models/device_role.go
+++ b/netbox/models/device_role.go
@@ -98,7 +98,7 @@ type DeviceRole struct {
 	// VM Role
 	//
 	// Virtual machines may be assigned to this role
-	VMRole bool `json:"vm_role,omitempty"`
+	VMRole *bool `json:"vm_role,omitempty"`
 }
 
 // Validate validates this device role

--- a/swagger.processed.json
+++ b/swagger.processed.json
@@ -72976,7 +72976,8 @@
         "vm_role": {
           "title": "VM Role",
           "description": "Virtual machines may be assigned to this role",
-          "type": "boolean"
+          "type": "boolean",
+          "x-nullable": true
         },
         "description": {
           "title": "Description",


### PR DESCRIPTION
## Problem

`DeviceRole.vm_role` is a plain `boolean`, which generates:

```go
VMRole bool `json:"vm_role,omitempty"`
```

Because of `omitempty`, a `false` value is **omitted from the request**, so Netbox falls back to its own server-side default (`true`). A client therefore cannot store `vm_role = false`, which causes perpetual `true → false` drift in the terraform-provider-netbox (e-breuninger/terraform-provider-netbox#820).

## Fix

Mark the `vm_role` property `x-nullable: true` in `swagger.processed.json` and regenerate. The generated field becomes:

```go
VMRole *bool `json:"vm_role,omitempty"`
```

A non-nil pointer to `false` now serialises as `"vm_role": false`, so clients can set it explicitly. Regeneration touches only `netbox/models/device_role.go`.

## Verification

With this change, the terraform provider's device-role acceptance tests (including a new regression test that round-trips `vm_role` through `true` and `false`) pass with no perpetual diff against NetBox 4.4.10.